### PR TITLE
Refactor event management: introduce Event model and admin commands

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -5,7 +5,7 @@ from enum import Enum
 from loguru import logger
 from pydantic import SecretStr, BaseModel, Field
 from pydantic_settings import BaseSettings
-from typing import Optional, Tuple, List, Dict
+from typing import Optional, Tuple, List, Dict, Union
 
 from botspot import get_database
 from botspot.utils import send_safe
@@ -101,7 +101,7 @@ class RegisteredUser(BaseModel):
     full_name: str
     graduation_year: int
     class_letter: str
-    target_city: TargetCity
+    target_city: Union[TargetCity, str]
     event_id: Optional[str] = None
     user_id: Optional[int] = None
     username: Optional[str] = None
@@ -308,14 +308,21 @@ class App:
             base = event.get("price_formula_base", 0)
             rate = event.get("price_formula_rate", 0)
             ref_year = event.get("price_formula_reference_year", 2026)
+            step = event.get("price_formula_step", 1)
             years_since = max(0, ref_year - graduation_year)
-            formula_amount = base + rate * years_since
+            if step > 1:
+                formula_amount = (years_since // step) * rate + base
+            else:
+                formula_amount = base + rate * years_since
 
             # Cap for old graduates (15+ years)
             regular_amount = formula_amount
             if years_since > 15:
                 # Cap at what 15-year grad would pay
-                regular_amount = base + rate * 15
+                if step > 1:
+                    regular_amount = (15 // step) * rate + base
+                else:
+                    regular_amount = base + rate * 15
 
             # Non-graduates get fixed recommended amount
             if graduate_type == GraduateType.NON_GRADUATE.value:
@@ -358,7 +365,8 @@ class App:
         # Convert the model to a dict and extract the enum value before saving
         data = registered_user.model_dump()
         # Convert the enums to their string values for MongoDB storage
-        data["target_city"] = data["target_city"].value
+        if hasattr(data["target_city"], "value"):
+            data["target_city"] = data["target_city"].value
         if "graduate_type" in data and isinstance(data["graduate_type"], GraduateType):
             data["graduate_type"] = data["graduate_type"].value.upper()  # Ensure uppercase
 

--- a/app/migrations.py
+++ b/app/migrations.py
@@ -217,9 +217,10 @@ async def seed_2026_spring_events(app):
             "status": "upcoming",
             "enabled": True,
             "pricing_type": "formula",
-            "price_formula_base": 1000,
-            "price_formula_rate": 200,
-            "price_formula_reference_year": 2026,
+            "price_formula_base": 1500,
+            "price_formula_rate": 450,
+            "price_formula_reference_year": 2025,
+            "price_formula_step": 3,
             "free_for_types": ["TEACHER", "ORGANIZER"],
             "created_at": datetime.now(),
             "updated_at": datetime.now(),
@@ -235,8 +236,12 @@ async def seed_2026_spring_events(app):
             "address": None,
             "status": "upcoming",
             "enabled": True,
-            "pricing_type": "free",
-            "free_for_types": [],
+            "pricing_type": "formula",
+            "price_formula_base": 900,
+            "price_formula_rate": 350,
+            "price_formula_reference_year": 2025,
+            "price_formula_step": 3,
+            "free_for_types": ["TEACHER", "ORGANIZER"],
             "created_at": datetime.now(),
             "updated_at": datetime.now(),
         },
@@ -270,3 +275,46 @@ async def seed_2026_spring_events(app):
             logger.info(f"Seeded event: {event_data['name']}")
         else:
             logger.info(f"Event already exists: {event_data['name']}, skipping.")
+
+
+# ============================================================
+# Migration: Update 2026 pricing formulas
+# ============================================================
+@migration("003_update_2026_pricing")
+async def update_2026_pricing(app):
+    """Update Moscow and SPb 2026 events with stepped pricing formulas."""
+    # Moscow: ((2025 - year) // 3) * 450 + 1500
+    result = await app.events_col.update_one(
+        {"city": "Москва", "date": datetime(2026, 3, 21, 18, 0)},
+        {
+            "$set": {
+                "pricing_type": "formula",
+                "price_formula_base": 1500,
+                "price_formula_rate": 450,
+                "price_formula_reference_year": 2025,
+                "price_formula_step": 3,
+                "free_for_types": ["TEACHER", "ORGANIZER"],
+                "updated_at": datetime.now(),
+            }
+        },
+    )
+    if result.modified_count > 0:
+        logger.info("Updated Moscow 2026 pricing formula")
+
+    # Saint Petersburg: ((2025 - year) // 3) * 350 + 900
+    result = await app.events_col.update_one(
+        {"city": "Санкт-Петербург", "date": datetime(2026, 3, 28, 17, 0)},
+        {
+            "$set": {
+                "pricing_type": "formula",
+                "price_formula_base": 900,
+                "price_formula_rate": 350,
+                "price_formula_reference_year": 2025,
+                "price_formula_step": 3,
+                "free_for_types": ["TEACHER", "ORGANIZER"],
+                "updated_at": datetime.now(),
+            }
+        },
+    )
+    if result.modified_count > 0:
+        logger.info("Updated Saint Petersburg 2026 pricing formula")

--- a/app/router.py
+++ b/app/router.py
@@ -497,11 +497,13 @@ async def register_user(
                 log_messages[user_id].append(log_msg)
             return
 
-        # Build choices from available events
+        # Build choices from available events (use city name as key for display)
         available_cities = {}
+        city_to_event = {}
         for e in available_events:
-            eid = str(e["_id"])
-            available_cities[eid] = f"{e['city']} ({e.get('date_display', '')})"
+            city_name = e["city"]
+            available_cities[city_name] = f"{city_name} ({e.get('date_display', '')})"
+            city_to_event[city_name] = e
         available_cities["cancel"] = "Отменить регистрацию"
 
         question = dedent(
@@ -529,8 +531,11 @@ async def register_user(
             )
             return
 
-        # Response is an event_id
-        selected_event = event_map.get(response)
+        # Response is a city name
+        selected_event = city_to_event.get(response)
+        if not selected_event:
+            # Fallback: try event_map by ID (legacy)
+            selected_event = event_map.get(response)
         if selected_event:
             # Set location from event city for backward compat
             location = next((c for c in TargetCity if c.value == selected_event["city"]), None)
@@ -790,15 +795,13 @@ async def register_user(
     if location:
         target_city_value = location
     elif selected_event:
-        # For new events not in TargetCity enum, find best match or use city name
+        # For new events not in TargetCity enum, find best match or use city name directly
         target_city_value = next(
             (c for c in TargetCity if c.value == selected_event["city"]), None
         )
         if not target_city_value:
-            # Use PERM as fallback for Пермь, MOSCOW for Москва, etc.
-            target_city_value = next(
-                (c for c in TargetCity if c.value == selected_event["city"]), TargetCity.PERM
-            )
+            # City not in TargetCity enum - use city name string directly
+            target_city_value = selected_event["city"]
 
     # Internal validation - log error but don't expose to user
     if not all([full_name, graduation_year is not None, class_letter, graduate_type]):

--- a/app/routers/payment.py
+++ b/app/routers/payment.py
@@ -69,25 +69,30 @@ def parse_payment_callback_data(callback_data: str) -> tuple[int, str, str | Non
     parts = data.split("_")
     if len(parts) < 2:
         raise ValueError("Invalid callback data structure")
-    
+
     user_id = int(parts[0])
-    
+
     # Handle city codes that might contain underscores
     if len(parts) >= 3:
-        # Check if the last part is a number (amount)
-        try:
-            amount_str = parts[-1]
-            int(amount_str)  # Test if it's a number
-            # If it's a number, everything in between is the city code
+        last_part = parts[-1]
+        # Check if the last part is a number (amount) or "custom"
+        if last_part == "custom":
             city_code = "_".join(parts[1:-1])
-        except ValueError:
-            # Last part is not a number, so it's part of the city code
-            city_code = "_".join(parts[1:])
-            amount_str = None
+            amount_str = "custom"
+        else:
+            try:
+                int(last_part)  # Test if it's a number
+                # If it's a number, everything in between is the city code
+                city_code = "_".join(parts[1:-1])
+                amount_str = last_part
+            except ValueError:
+                # Last part is not a number and not "custom", so it's part of the city code
+                city_code = "_".join(parts[1:])
+                amount_str = None
     else:
         city_code = parts[1]
         amount_str = None
-    
+
     return user_id, city_code, amount_str
 
 
@@ -125,10 +130,20 @@ async def process_payment(
         if registration and "graduate_type" in registration:
             graduate_type = registration["graduate_type"]
 
-    # Calculate payment amount
-    regular_amount, discount, discounted_amount, formula_amount = app.calculate_payment_amount(
-        city, graduation_year, graduate_type
-    )
+    # Calculate payment amount - try event-based calculation first
+    registration_data = await app.collection.find_one({"user_id": user_id, "target_city": city})
+    event = None
+    if registration_data:
+        event = await app.get_event_for_registration(registration_data)
+
+    if event:
+        regular_amount, discount, discounted_amount, formula_amount = app.calculate_event_payment(
+            event, graduation_year, graduate_type
+        )
+    else:
+        regular_amount, discount, discounted_amount, formula_amount = app.calculate_payment_amount(
+            city, graduation_year, graduate_type
+        )
 
     # Only show instructions if not skipped
     if not skip_instructions:
@@ -139,12 +154,6 @@ async def process_payment(
         await asyncio.sleep(3)  # 3 second delay
 
         # Prepare payment message - get formula from event data or fallback
-        # Try to load event from registration
-        registration_data = await app.collection.find_one({"user_id": user_id, "target_city": city})
-        event = None
-        if registration_data:
-            event = await app.get_event_for_registration(registration_data)
-
         if event:
             pricing_type = event.get("pricing_type", "formula")
             if pricing_type == "free":
@@ -155,7 +164,11 @@ async def process_payment(
                 base = event.get("price_formula_base", 0)
                 rate = event.get("price_formula_rate", 0)
                 ref_year = event.get("price_formula_reference_year", 2026)
-                payment_formula = f"{base}р + {rate} × ({ref_year} − год выпуска)"
+                step = event.get("price_formula_step", 1)
+                if step > 1:
+                    payment_formula = f"(({ref_year} − год выпуска) ÷ {step}) × {rate} + {base}р"
+                else:
+                    payment_formula = f"{base}р + {rate} × ({ref_year} − год выпуска)"
             else:
                 payment_formula = "за свой счет"
         elif city == TargetCity.MOSCOW.value:


### PR DESCRIPTION
## Summary

This PR introduces a proper Event data model and database-driven event management to replace hardcoded event metadata scattered across multiple files. It includes admin-only commands to create and manage events directly through the bot, eliminates the need for code deployments when adding new meetups, and archives legacy 2025 events.

## Key Changes

### Event Data Model & Database
- **New `Event` model** in `app.py` with fields for name, city, date, venue, pricing, and status
- **New `EventStatus` enum** (upcoming, registration_closed, passed, archived) and `PricingType` enum (formula, fixed_by_year, free)
- **MongoDB `events` collection** to store event documents, replacing hardcoded dictionaries
- **Migration framework** (`app/migrations.py`) for idempotent database initialization and schema updates

### Admin Event Management
- **New `/create_event` command** with guided multi-step flow to create events without code changes
  - Collects city, date, time, venue, address, and pricing details
  - Auto-suggests event names based on season and year
  - Supports formula-based pricing (base + rate × years since reference year)
- **New `/manage_events` command** to view, edit, enable/disable, and archive events
- **New `app/routers/events.py`** router with admin-only event management handlers

### Data Migration & Cleanup
- **Migration `001_archive_2025_events`** creates archived Event documents for all 2025 events and links existing registrations to them
- **Initial event seeding** with three 2026 meetups (Moscow, Saint Petersburg, Perm) on first startup
- **Auto-status updates** to mark events as passed based on current date

### Refactored Event Access
- **Helper functions** in `router.py`:
  - `get_event_date_display()` - fetch display date from event dict
  - `get_event_city()` - fetch city name from event dict
  - `is_event_free()` - check if event is free for a given graduate type
- **App methods** for event queries:
  - `get_user_active_registrations()` - exclude archived events
  - `get_event_for_registration()` - fetch Event document for a registration
  - `_update_event_statuses()` - auto-update event status based on date

### Code Cleanup
- Removed hardcoded dictionaries: `date_of_event`, `event_dates`, `time_of_event`, `venue_of_event`, `address_of_event`, `padezhi`
- Removed `is_event_passed()` function (replaced by event status field)
- Removed `ENABLED_CITIES` dict (replaced by event `enabled` flag)
- Updated `handle_registered_user()` to work with Event documents instead of enum-based lookups
- Updated payment and CRM routers to fetch event data from database

### Documentation
- **PRD 00** - Central coordination document for the 2026 update
- **PRD 01** - Event data model specification
- **PRD 02** - Database initialization and event seeding
- **PRD 03** - Old data cleanup and archival strategy
- **PRD 04** - Admin event management commands

## Implementation Details

- Event creation uses FSM states for conversational flow
- Pricing formulas support dynamic calculation: `base + rate × (reference_year - graduation_year)`
- Events can be marked as free for specific graduate types (teachers, organizers)
- Registrations now include optional `event_id` field linking to Event documents
- Backward compatibility maintained: `TargetCity` enum kept for existing registrations
- City prepositional case mapping (`CITY_PREPOSITIONAL_MAP`) supports common Russian cities

https://claude.ai/code/session_01KzhwBXFD5G49TjjceQgBmp