### PR TITLE
Add plus-one guest support with configurable pricing strategies

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -26,6 +26,17 @@ class GraduateType(str, Enum):
     ORGANIZER = "ORGANIZER"
 
 
+class PlusOnePricingStrategy(str, Enum):
+    SAME_AS_REGISTRANT = "same_as_registrant"
+    SAME_WITH_MINIMUM = "same_with_minimum"
+
+
+class GuestInfo(BaseModel):
+    full_name: str
+    relationship: str
+    payment_amount: int = 0
+
+
 # Mapping for human-readable graduate types
 GRADUATE_TYPE_MAP = {
     GraduateType.GRADUATE.value: "Выпускник",
@@ -77,6 +88,7 @@ class RegisteredUser(BaseModel):
     user_id: Optional[int] = None
     username: Optional[str] = None
     graduate_type: GraduateType = GraduateType.GRADUATE
+    guests: List[GuestInfo] = []
 
 
 class FeedbackData(BaseModel):
@@ -129,9 +141,33 @@ class App:
         TargetCity.BELGRADE.value: False,
     }
 
-    def is_city_enabled(self,city: str) -> bool:
+    # Plus-one guest configuration per event
+    PLUS_ONE_CONFIG: Dict[str, dict] = {
+        TargetCity.PERM_SUMMER_2025.value: {
+            "enabled": True,
+            "max_guests": 2,
+            "pricing_strategy": PlusOnePricingStrategy.SAME_WITH_MINIMUM,
+            "min_guest_price": 1500,
+        },
+    }
+
+    def is_city_enabled(self, city: str) -> bool:
         """Check if a city is enabled for registration"""
         return self.ENABLED_CITIES.get(city, False)
+
+    def get_plus_one_config(self, city: str) -> dict:
+        """Get plus-one configuration for a city"""
+        return self.PLUS_ONE_CONFIG.get(city, {})
+
+    def calculate_guest_price(self, city: str, registrant_price: int) -> int:
+        """Calculate the price for a guest based on the city's pricing strategy"""
+        config = self.get_plus_one_config(city)
+        if not config.get("enabled", False):
+            return registrant_price
+        strategy = config.get("pricing_strategy", PlusOnePricingStrategy.SAME_AS_REGISTRANT)
+        if strategy == PlusOnePricingStrategy.SAME_WITH_MINIMUM:
+            return max(registrant_price, config.get("min_guest_price", 0))
+        return registrant_price
 
     async def startup(self):
         """
@@ -181,6 +217,10 @@ class App:
         if "graduate_type" in data and isinstance(data["graduate_type"], GraduateType):
             data["graduate_type"] = data["graduate_type"].value.upper()  # Ensure uppercase
 
+        # Convert guests list to dicts for MongoDB storage
+        if data.get("guests"):
+            data["guests"] = [g if isinstance(g, dict) else g for g in data["guests"]]
+
         # Add user_id and username if provided
         if user_id is not None:
             data["user_id"] = user_id
@@ -218,6 +258,27 @@ class App:
 
         # Log the registration action
         await self.save_event_log("user_registration", log_data, user_id, username)
+
+    async def save_guests(
+        self, user_id: int, city: str, guests: List[GuestInfo]
+    ) -> None:
+        """Save guest list for a user's registration"""
+        guests_data = [g.model_dump() if isinstance(g, GuestInfo) else g for g in guests]
+        await self.collection.update_one(
+            {"user_id": user_id, "target_city": city},
+            {"$set": {"guests": guests_data}},
+        )
+
+        await self.save_event_log(
+            "guests_added",
+            {
+                "action": "save_guests",
+                "city": city,
+                "guest_count": len(guests),
+                "guests": [{"full_name": g.full_name, "relationship": g.relationship} for g in guests if isinstance(g, GuestInfo)],
+            },
+            user_id,
+        )
 
     async def get_user_registrations(self, user_id: int):
         """Get all registrations for a user"""

--- a/app/export.py
+++ b/app/export.py
@@ -125,6 +125,9 @@ class SheetExporter:
             "Регулярная сумма",
             "Формула",
             "Дата оплаты",
+            "Кол-во гостей",
+            "Гости",
+            "Сумма за гостей",
         ]
 
         # Update all sheets with headers
@@ -156,6 +159,15 @@ class SheetExporter:
                 graduate_type, "Выпускник"
             )  # Default to "Выпускник" if type is unknown
 
+            # Guest info
+            guests = user.get("guests", [])
+            guest_count = len(guests)
+            guest_names = "; ".join(
+                f"{g.get('full_name', '')} ({g.get('relationship', '')}, {g.get('payment_amount', 0)}₽)"
+                for g in guests
+            ) if guests else ""
+            guest_payment_total = sum(g.get("payment_amount", 0) for g in guests)
+
             # Create a row of user data
             user_row = [
                 user["full_name"],
@@ -170,6 +182,9 @@ class SheetExporter:
                 regular_amount,
                 formula_amount,
                 payment_timestamp,
+                guest_count,
+                guest_names,
+                guest_payment_total,
             ]
 
             # Add to main sheet
@@ -244,6 +259,9 @@ class SheetExporter:
                 "Регулярная сумма",
                 "Формула",
                 "Дата оплаты",
+                "Кол-во гостей",
+                "Гости",
+                "Сумма за гостей",
             ]
             writer.writerow(headers)
 
@@ -268,6 +286,15 @@ class SheetExporter:
                     graduate_type, "Выпускник"
                 )  # Default to "Выпускник" if type is unknown
 
+                # Guest info
+                guests = user.get("guests", [])
+                guest_count = len(guests)
+                guest_names = "; ".join(
+                    f"{g.get('full_name', '')} ({g.get('relationship', '')}, {g.get('payment_amount', 0)}₽)"
+                    for g in guests
+                ) if guests else ""
+                guest_payment_total = sum(g.get("payment_amount", 0) for g in guests)
+
                 writer.writerow(
                     [
                         user["full_name"],
@@ -282,6 +309,9 @@ class SheetExporter:
                         regular_amount,
                         formula_amount,
                         payment_timestamp,
+                        guest_count,
+                        guest_names,
+                        guest_payment_total,
                     ]
                 )
 

--- a/app/router.py
+++ b/app/router.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from typing import Dict, List
 from datetime import datetime
 
-from app.app import App, TargetCity, RegisteredUser, GraduateType
+from app.app import App, TargetCity, RegisteredUser, GraduateType, GuestInfo
 from app.routers.admin import admin_handler
 from botspot import commands_menu
 from botspot.user_interactions import ask_user, ask_user_choice
@@ -114,8 +114,15 @@ async def handle_registered_user(message: Message, state: FSMContext, registrati
             info_text += f"• {city} ({date_of_event[city_enum] if city_enum else 'дата неизвестна'}){payment_status}\n"
             info_text += f"  ФИО: {reg['full_name']}\n"
             info_text += (
-                f"  Год выпуска: {reg['graduation_year']}, Класс: {reg['class_letter']}\n\n"
+                f"  Год выпуска: {reg['graduation_year']}, Класс: {reg['class_letter']}\n"
             )
+            # Show guests if any
+            guests = reg.get("guests", [])
+            if guests:
+                info_text += f"  👥 Гости ({len(guests)}): "
+                info_text += ", ".join(g.get("full_name", "") for g in guests)
+                info_text += "\n"
+            info_text += "\n"
 
         info_text += "Что вы хотите сделать?"
 
@@ -196,6 +203,12 @@ async def handle_registered_user(message: Message, state: FSMContext, registrati
         info_text += (
             f"Город: {city} ({date_of_event[city_enum] if city_enum else 'дата неизвестна'})\n"
         )
+        # Show guests if any
+        reg_guests = reg.get("guests", [])
+        if reg_guests:
+            info_text += f"👥 Гости ({len(reg_guests)}): "
+            info_text += ", ".join(g.get("full_name", "") for g in reg_guests)
+            info_text += "\n"
         info_text += payment_status
         info_text += "\nЧто вы хотите сделать?"
 
@@ -867,6 +880,95 @@ async def register_user(
     # Clear log messages
     await delete_log_messages(user_id)
 
+    # Calculate payment amount early (needed for guest pricing)
+    regular_amount, discount, discounted_amount, formula_amount = app.calculate_payment_amount(
+        location.value, graduation_year, graduate_type.value
+    )
+
+    # --- Plus-one guest flow ---
+    guests = []
+    plus_one_cfg = app.get_plus_one_config(location.value)
+    if plus_one_cfg.get("enabled", False):
+        max_guests = plus_one_cfg.get("max_guests", 1)
+
+        while len(guests) < max_guests:
+            prompt_text = "Хотите зарегистрировать кого-то с собой? (+1)" if not guests else "Хотите добавить ещё одного гостя?"
+            add_guest = await ask_user_choice(
+                message.chat.id,
+                prompt_text,
+                choices={"yes": "Да, добавить гостя", "no": "Нет, продолжить"},
+                state=state,
+                timeout=None,
+            )
+            if add_guest != "yes":
+                break
+
+            # Collect guest name with validation
+            guest_name = None
+            while guest_name is None:
+                name_response = await ask_user(
+                    message.chat.id,
+                    "Введите имя и фамилию гостя:",
+                    state=state,
+                    timeout=None,
+                )
+                if name_response is None:
+                    await send_safe(
+                        message.chat.id,
+                        "⏰ Время ожидания истекло. Гости не будут добавлены.",
+                    )
+                    break
+                valid, error = app.validate_full_name(name_response)
+                if valid:
+                    guest_name = name_response
+                else:
+                    await send_safe(message.chat.id, f"❌ {error} Пожалуйста, попробуйте еще раз.")
+
+            if guest_name is None:
+                break
+
+            # Collect relationship
+            rel_response = await ask_user_choice(
+                message.chat.id,
+                f"Кем вам приходится {guest_name}?",
+                choices={
+                    "Супруг(а)": "Супруг(а)",
+                    "Друг/Подруга": "Друг/Подруга",
+                    "Коллега": "Коллега",
+                    "other": "Другое",
+                },
+                state=state,
+                timeout=None,
+            )
+            if rel_response == "other":
+                rel_response = await ask_user(
+                    message.chat.id,
+                    "Укажите, кем вам приходится гость:",
+                    state=state,
+                    timeout=None,
+                )
+                if rel_response is None:
+                    rel_response = "Другое"
+
+            # Calculate guest price
+            guest_price = app.calculate_guest_price(location.value, regular_amount)
+
+            guest = GuestInfo(
+                full_name=guest_name,
+                relationship=rel_response,
+                payment_amount=guest_price,
+            )
+            guests.append(guest)
+
+            await send_safe(
+                message.chat.id,
+                f"✅ Гость добавлен: {guest_name} ({rel_response}), стоимость: {guest_price} руб.",
+            )
+
+    # Save guests to DB
+    if guests:
+        await app.save_guests(user_id, location.value, guests)
+
     # Send confirmation message with payment info in one message
     confirmation_msg = (
         f"Спасибо, {full_name}!\n"
@@ -952,11 +1054,7 @@ async def register_user(
         await app.export_registered_users_to_google_sheets()
     else:
         # Regular flow for everyone else who needs to pay
-
-        # Calculate payment amounts first
-        regular_amount, discount, discounted_amount, formula_amount = app.calculate_payment_amount(
-            location.value, graduation_year, graduate_type.value
-        )
+        # (regular_amount, discount, discounted_amount, formula_amount already calculated above)
 
         # Save payment info with "not paid" status - different from "pending" which is used after "pay later" click
         await app.save_payment_info(
@@ -980,7 +1078,8 @@ async def register_user(
 
         # Process payment directly
         await process_payment(
-            message, state, location.value, graduation_year, graduate_type=graduate_type.value
+            message, state, location.value, graduation_year,
+            graduate_type=graduate_type.value, guests=guests,
         )
 
 

--- a/app/routers/payment.py
+++ b/app/routers/payment.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from loguru import logger
 from textwrap import dedent
 
-from app.app import App, TargetCity, GraduateType
+from app.app import App, TargetCity, GraduateType, GuestInfo
 from app.router import is_admin, date_of_event, commands_menu
 from app.routers.admin import PaymentInfo
 from botspot.user_interactions import ask_user_raw, ask_user_choice, ask_user_choice_raw
@@ -98,6 +98,7 @@ async def process_payment(
     graduation_year: int,
     skip_instructions=False,
     graduate_type: str = GraduateType.GRADUATE.value,
+    guests: list = None,
 ):
     """Process payment for an event registration"""
     # Check if we have original user information in the state
@@ -129,6 +130,20 @@ async def process_payment(
     regular_amount, discount, discounted_amount, formula_amount = app.calculate_payment_amount(
         city, graduation_year, graduate_type
     )
+
+    # Calculate total amount including guests
+    if guests is None:
+        guests = []
+    # Try to load guests from registration if not passed directly
+    if not guests and user_id:
+        reg = await app.get_user_registration(user_id)
+        if reg and reg.get("guests"):
+            guests = [
+                GuestInfo(**g) if isinstance(g, dict) else g
+                for g in reg["guests"]
+            ]
+    guest_total = sum(g.payment_amount for g in guests) if guests else 0
+    total_amount = regular_amount + guest_total
 
     # Only show instructions if not skipped
     if not skip_instructions:
@@ -168,13 +183,28 @@ async def process_payment(
 
         # For summer 2025 event, no early registration discount
         if city == TargetCity.PERM_SUMMER_2025.value:
-            payment_msg_part2 = dedent(
-                f"""
-                Стоимость билета для вашего года выпуска: {regular_amount} руб.
-                
-                Приятно будет увидеть вас на летней встрече! 😊
-                """
-            )
+            if guests:
+                guest_lines = "\n".join(
+                    f"Гость ({g.full_name}): {g.payment_amount} руб." for g in guests
+                )
+                payment_msg_part2 = dedent(
+                    f"""
+                    Стоимость билета для вашего года выпуска: {regular_amount} руб.
+                    {guest_lines}
+
+                    Итого к оплате: {total_amount} руб.
+
+                    Приятно будет увидеть вас на летней встрече! 😊
+                    """
+                )
+            else:
+                payment_msg_part2 = dedent(
+                    f"""
+                    Стоимость билета для вашего года выпуска: {regular_amount} руб.
+
+                    Приятно будет увидеть вас на летней встрече! 😊
+                    """
+                )
         else:
             # Check if we're before the early registration deadline (for old events)
             today = datetime.now()
@@ -405,6 +435,11 @@ async def process_payment(
             else:
                 needs_to_pay = f"{regular_amount} руб"
 
+            # Build payment summary including guests
+            if guests:
+                needs_to_pay = f"{total_amount} руб (своих {regular_amount} + гости {guest_total})"
+            # else needs_to_pay is already set above
+
             # Get user info for the message
             user_info = f"👤 Пользователь: {username or ''} (ID: {user_id})\n"
             user_info += f"📍 Город: {city}\n"
@@ -423,6 +458,12 @@ async def process_payment(
                     user_info += f"👥 Статус: Друг школы (не выпускник)\n"
                 else:
                     user_info += f"🎓 Выпуск: {user_registration.get('graduation_year', 'Неизвестно')} {user_registration.get('class_letter', '')}\n"
+
+            # Add guest info to admin message
+            if guests:
+                user_info += f"👥 Гости ({len(guests)}):\n"
+                for g in guests:
+                    user_info += f"  • {g.full_name} ({g.relationship}) — {g.payment_amount} руб.\n"
 
             # Get bot instance
             from botspot.core.dependency_manager import get_dependency_manager
@@ -464,6 +505,17 @@ async def process_payment(
                     ]
                 )
             else:
+                # Add total amount button when guests are present
+                if guests and total_amount != regular_amount:
+                    validation_buttons.append(
+                        [
+                            InlineKeyboardButton(
+                                text=f"✅ {total_amount} руб. - Подтвердить (с гостями)",
+                                callback_data=f"confirm_payment_{user_id}_{city_code}_{total_amount}",
+                            )
+                        ]
+                    )
+
                 # Add standard buttons for different amounts
                 if today < EARLY_REGISTRATION_DATE:
                     validation_buttons.append(

--- a/app/routers/stats.py
+++ b/app/routers/stats.py
@@ -76,7 +76,23 @@ async def show_stats(message: Message, app: App):
 
     total = total_active + total_deleted
     deleted_percentage = f" ({total_deleted/total:.1%} удаленных)" if total > 0 else ""
-    stats_text += f"\nВсего: <b>{total}</b> человек{deleted_percentage}\n\n"
+    stats_text += f"\nВсего: <b>{total}</b> человек{deleted_percentage}\n"
+
+    # Guest statistics
+    guest_cursor = app.collection.aggregate([
+        {"$project": {"target_city": 1, "guest_count": {"$size": {"$ifNull": ["$guests", []]}}}},
+        {"$group": {"_id": "$target_city", "total_guests": {"$sum": "$guest_count"}}},
+    ])
+    guest_stats = await guest_cursor.to_list(length=None)
+    total_guests = sum(s["total_guests"] for s in guest_stats)
+    if total_guests > 0:
+        stats_text += f"👥 Гости: <b>{total_guests}</b> чел."
+        guest_by_city = {s["_id"]: s["total_guests"] for s in guest_stats if s["total_guests"] > 0}
+        if guest_by_city:
+            parts = [f"{city}: {cnt}" for city, cnt in sorted(guest_by_city.items())]
+            stats_text += f" ({', '.join(parts)})"
+        stats_text += f"\n🧑‍🤝‍🧑 Всего людей (с гостями): <b>{total_active + total_guests}</b>\n"
+    stats_text += "\n"
 
     # 2. Distribution by graduate type (combine active and deleted)
     # Active users
@@ -477,7 +493,23 @@ async def show_simple_stats(message: Message, app: App):
 
     total = total_active + total_deleted
     deleted_percentage = f" ({total_deleted/total:.1%} удаленных)" if total > 0 else ""
-    stats_text += f"\nВсего: <b>{total}</b> человек{deleted_percentage}\n\n"
+    stats_text += f"\nВсего: <b>{total}</b> человек{deleted_percentage}\n"
+
+    # Guest statistics
+    guest_cursor = app.collection.aggregate([
+        {"$project": {"target_city": 1, "guest_count": {"$size": {"$ifNull": ["$guests", []]}}}},
+        {"$group": {"_id": "$target_city", "total_guests": {"$sum": "$guest_count"}}},
+    ])
+    guest_stats = await guest_cursor.to_list(length=None)
+    total_guests = sum(s["total_guests"] for s in guest_stats)
+    if total_guests > 0:
+        stats_text += f"👥 Гости: <b>{total_guests}</b> чел."
+        guest_by_city = {s["_id"]: s["total_guests"] for s in guest_stats if s["total_guests"] > 0}
+        if guest_by_city:
+            parts = [f"{city}: {cnt}" for city, cnt in sorted(guest_by_city.items())]
+            stats_text += f" ({', '.join(parts)})"
+        stats_text += f"\n🧑‍🤝‍🧑 Всего людей (с гостями): <b>{total_active + total_guests}</b>\n"
+    stats_text += "\n"
 
     # 2. Distribution by graduate type (combine active and deleted)
     # Active users

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,153 @@
+# Plus-One Support — Implementation Plan
+
+## Summary
+
+Allow registrants to bring additional guests (significant others, friends). Guests are stored as a nested list on the main registration document. Pricing supports two admin-configurable strategies. Max guests per event is configurable.
+
+---
+
+## Data Model Changes
+
+### 1. New `GuestInfo` model (`app/app.py`)
+
+```python
+class GuestInfo(BaseModel):
+    full_name: str                        # Required, same validation as main registrant
+    relationship: str                     # e.g. "супруг(а)", "друг/подруга", "коллега", "другое"
+    payment_amount: Optional[int] = None  # Calculated price for this guest
+```
+
+### 2. New `PlusOnePricingStrategy` enum (`app/app.py`)
+
+```python
+class PlusOnePricingStrategy(str, Enum):
+    SAME_AS_REGISTRANT = "same_as_registrant"          # Guest pays same as registrant
+    SAME_WITH_MINIMUM = "same_with_minimum"             # Same, but not less than min_guest_price
+```
+
+### 3. Extend `RegisteredUser` model
+
+Add field:
+```python
+guests: List[GuestInfo] = []
+```
+
+### 4. Event-level configuration (new dict in `router.py` or `app.py`)
+
+```python
+plus_one_config = {
+    TargetCity.PERM_SUMMER_2025: {
+        "enabled": True,
+        "max_guests": 2,
+        "pricing_strategy": PlusOnePricingStrategy.SAME_WITH_MINIMUM,
+        "min_guest_price": 1500,  # Only used when strategy is SAME_WITH_MINIMUM
+    },
+    # Other cities default to disabled
+}
+```
+
+### 5. Data storage recommendation: **Nested list**
+
+Guests stored as `guests: [GuestInfo, ...]` inside `RegisteredUser`. Reasons:
+- Guests don't have independent Telegram accounts — no reason for separate docs
+- Payment is handled together with the registrant
+- Simpler queries, exports, and admin views
+- No orphan records to worry about
+
+---
+
+## Registration Flow Changes (`app/router.py`)
+
+### New FSM states
+
+```python
+class RegistrationStates(StatesGroup):
+    # ... existing states ...
+    ask_plus_one = State()              # "Want to bring someone?"
+    guest_name = State()                # Collect guest name
+    guest_relationship = State()        # Collect relationship
+    ask_another_guest = State()         # "Add another guest?"
+```
+
+### Flow (inserted after graduation year / class letter, before payment)
+
+1. **Ask plus-one** — "Хотите зарегистрировать кого-то с собой? (+1)"
+   - Show only if `plus_one_config[city].enabled` and guest count < max
+   - Buttons: "Да" / "Нет, продолжить"
+
+2. **Guest name** — "Введите имя и фамилию гостя"
+   - Same Russian-name validation as main registrant
+
+3. **Guest relationship** — "Кем вам приходится гость?"
+   - Inline buttons: "Супруг(а)", "Друг/Подруга", "Коллега", "Другое"
+   - If "Другое" → free text input
+
+4. **Calculate guest price** — Apply pricing strategy:
+   - `SAME_AS_REGISTRANT`: guest_price = registrant_price
+   - `SAME_WITH_MINIMUM`: guest_price = max(registrant_price, min_guest_price)
+
+5. **Confirm guest** — "Гость: {name} ({relationship}). Стоимость: {price} руб."
+
+6. **Ask another?** — If guest_count < max_guests:
+   - "Хотите добавить ещё гостя?" → loop back to step 2
+   - Otherwise proceed to payment
+
+7. **Payment summary** — Show total: registrant_price + sum(guest_prices)
+
+---
+
+## Payment Changes (`app/routers/payment.py`)
+
+### Modified payment message
+
+- Show itemized breakdown:
+  ```
+  Ваш взнос: 1500 руб
+  Гость (Анна Иванова): 1500 руб
+  Итого: 3000 руб
+  ```
+- Total payment expected = registrant + all guests
+- Admin sees guest details in the payment validation message
+
+### Admin payment validation
+
+- Show guest info alongside registrant in the events chat message
+- Payment confirmation applies to the entire registration (registrant + guests)
+
+---
+
+## Export Changes (`app/export.py`)
+
+- Add columns for guests (e.g. `guest_1_name`, `guest_1_relationship`, `guest_1_price`, `guest_2_name`, ...)
+- Or add a single `guests` column with formatted text like "Анна Иванова (супруга, 1500₽)"
+
+---
+
+## Admin Visibility (`app/routers/admin.py`, `app/routers/stats.py`)
+
+- Stats should include guest counts (total registrations vs total people including guests)
+- Admin user info should show guest list
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `app/app.py` | Add `GuestInfo`, `PlusOnePricingStrategy`, extend `RegisteredUser` |
+| `app/router.py` | Add FSM states, plus-one flow, pricing logic, event config |
+| `app/routers/payment.py` | Itemized totals, guest info in admin messages |
+| `app/routers/admin.py` | Show guests in user info |
+| `app/routers/stats.py` | Include guest counts |
+| `app/export.py` | Add guest columns to spreadsheet export |
+| `tests/` | New tests for guest registration, pricing strategies |
+
+---
+
+## Edge Cases to Handle
+
+1. **User cancels registration mid-guest-flow** — guests already entered should be discarded (only save when full registration completes)
+2. **User re-registers** (edits existing registration) — should be able to modify guest list
+3. **Free events** (SPb, Belgrade, teachers, organizers) — guests should also be free
+4. **Deletion** — when registration is deleted, guests go with it (automatic with nested list)
+5. **Max guests = 0 or config missing** — treat as plus-one disabled for that event

--- a/tests/test_plus_one.py
+++ b/tests/test_plus_one.py
@@ -1,0 +1,334 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from app.app import (
+    App,
+    TargetCity,
+    GraduateType,
+    GuestInfo,
+    PlusOnePricingStrategy,
+    RegisteredUser,
+)
+
+
+class TestGuestModels:
+    """Tests for GuestInfo and PlusOnePricingStrategy models"""
+
+    def test_guest_info_creation(self):
+        """Test creating a GuestInfo instance"""
+        guest = GuestInfo(full_name="Иванова Анна", relationship="Супруг(а)", payment_amount=1500)
+        assert guest.full_name == "Иванова Анна"
+        assert guest.relationship == "Супруг(а)"
+        assert guest.payment_amount == 1500
+
+    def test_guest_info_default_payment(self):
+        """Test GuestInfo default payment amount is 0"""
+        guest = GuestInfo(full_name="Петров Петр", relationship="Друг/Подруга")
+        assert guest.payment_amount == 0
+
+    def test_guest_info_serialization(self):
+        """Test GuestInfo serialization to dict"""
+        guest = GuestInfo(full_name="Иванова Анна", relationship="Коллега", payment_amount=1800)
+        data = guest.model_dump()
+        assert data == {
+            "full_name": "Иванова Анна",
+            "relationship": "Коллега",
+            "payment_amount": 1800,
+        }
+
+    def test_registered_user_with_guests(self):
+        """Test RegisteredUser with guests list"""
+        guests = [
+            GuestInfo(full_name="Иванова Анна", relationship="Супруг(а)", payment_amount=1500),
+            GuestInfo(full_name="Петров Петр", relationship="Друг/Подруга", payment_amount=1500),
+        ]
+        user = RegisteredUser(
+            full_name="Иванов Иван",
+            graduation_year=2010,
+            class_letter="А",
+            target_city=TargetCity.PERM_SUMMER_2025,
+            guests=guests,
+        )
+        assert len(user.guests) == 2
+        assert user.guests[0].full_name == "Иванова Анна"
+        assert user.guests[1].payment_amount == 1500
+
+    def test_registered_user_empty_guests(self):
+        """Test RegisteredUser with no guests defaults to empty list"""
+        user = RegisteredUser(
+            full_name="Иванов Иван",
+            graduation_year=2010,
+            class_letter="А",
+            target_city=TargetCity.MOSCOW,
+        )
+        assert user.guests == []
+
+    def test_pricing_strategy_enum(self):
+        """Test PlusOnePricingStrategy enum values"""
+        assert PlusOnePricingStrategy.SAME_AS_REGISTRANT == "same_as_registrant"
+        assert PlusOnePricingStrategy.SAME_WITH_MINIMUM == "same_with_minimum"
+
+
+class TestGuestPricing:
+    """Tests for guest price calculation"""
+
+    def setup_method(self):
+        """Set up test environment before each test"""
+        mock_db = MagicMock()
+        mock_db.get_collection.return_value = AsyncMock()
+        self.db_patcher = patch("app.app.get_database", return_value=mock_db)
+        self.db_patcher.start()
+
+        self.app = App(
+            telegram_bot_token="mock_token",
+            payment_phone_number="1234567890",
+            payment_name="Test User",
+        )
+
+    def teardown_method(self):
+        self.db_patcher.stop()
+
+    def test_guest_price_same_as_registrant(self):
+        """Test SAME_AS_REGISTRANT strategy returns registrant price"""
+        # Override config for test
+        self.app.PLUS_ONE_CONFIG = {
+            "TestCity": {
+                "enabled": True,
+                "max_guests": 2,
+                "pricing_strategy": PlusOnePricingStrategy.SAME_AS_REGISTRANT,
+            },
+        }
+        price = self.app.calculate_guest_price("TestCity", 1800)
+        assert price == 1800
+
+    def test_guest_price_same_with_minimum_above(self):
+        """Test SAME_WITH_MINIMUM when registrant price > minimum"""
+        self.app.PLUS_ONE_CONFIG = {
+            "TestCity": {
+                "enabled": True,
+                "max_guests": 2,
+                "pricing_strategy": PlusOnePricingStrategy.SAME_WITH_MINIMUM,
+                "min_guest_price": 1500,
+            },
+        }
+        price = self.app.calculate_guest_price("TestCity", 1800)
+        assert price == 1800
+
+    def test_guest_price_same_with_minimum_below(self):
+        """Test SAME_WITH_MINIMUM when registrant price < minimum (floor applies)"""
+        self.app.PLUS_ONE_CONFIG = {
+            "TestCity": {
+                "enabled": True,
+                "max_guests": 2,
+                "pricing_strategy": PlusOnePricingStrategy.SAME_WITH_MINIMUM,
+                "min_guest_price": 1500,
+            },
+        }
+        price = self.app.calculate_guest_price("TestCity", 1300)
+        assert price == 1500
+
+    def test_guest_price_same_with_minimum_equal(self):
+        """Test SAME_WITH_MINIMUM when registrant price == minimum"""
+        self.app.PLUS_ONE_CONFIG = {
+            "TestCity": {
+                "enabled": True,
+                "max_guests": 2,
+                "pricing_strategy": PlusOnePricingStrategy.SAME_WITH_MINIMUM,
+                "min_guest_price": 1500,
+            },
+        }
+        price = self.app.calculate_guest_price("TestCity", 1500)
+        assert price == 1500
+
+    def test_guest_price_unconfigured_city(self):
+        """Test guest price for city without plus-one config"""
+        price = self.app.calculate_guest_price("NonexistentCity", 2000)
+        assert price == 2000
+
+    def test_guest_price_perm_summer_2025(self):
+        """Test guest price with actual PERM_SUMMER_2025 config"""
+        # Uses the default PLUS_ONE_CONFIG
+        price = self.app.calculate_guest_price(
+            TargetCity.PERM_SUMMER_2025.value, 1300
+        )
+        # min_guest_price is 1500, registrant pays 1300 -> guest pays 1500
+        assert price == 1500
+
+    def test_guest_price_perm_summer_2025_expensive(self):
+        """Test guest price when registrant price exceeds minimum"""
+        price = self.app.calculate_guest_price(
+            TargetCity.PERM_SUMMER_2025.value, 2200
+        )
+        # min_guest_price is 1500, registrant pays 2200 -> guest pays 2200
+        assert price == 2200
+
+
+class TestPlusOneConfig:
+    """Tests for plus-one configuration"""
+
+    def setup_method(self):
+        mock_db = MagicMock()
+        mock_db.get_collection.return_value = AsyncMock()
+        self.db_patcher = patch("app.app.get_database", return_value=mock_db)
+        self.db_patcher.start()
+
+        self.app = App(
+            telegram_bot_token="mock_token",
+            payment_phone_number="1234567890",
+            payment_name="Test User",
+        )
+
+    def teardown_method(self):
+        self.db_patcher.stop()
+
+    def test_get_plus_one_config_enabled_city(self):
+        """Test getting config for enabled city"""
+        config = self.app.get_plus_one_config(TargetCity.PERM_SUMMER_2025.value)
+        assert config["enabled"] is True
+        assert config["max_guests"] == 2
+        assert config["pricing_strategy"] == PlusOnePricingStrategy.SAME_WITH_MINIMUM
+        assert config["min_guest_price"] == 1500
+
+    def test_get_plus_one_config_unconfigured_city(self):
+        """Test getting config for unconfigured city returns empty dict"""
+        config = self.app.get_plus_one_config(TargetCity.MOSCOW.value)
+        assert config == {}
+
+    def test_get_plus_one_config_disabled_check(self):
+        """Test that unconfigured cities have plus-one disabled"""
+        config = self.app.get_plus_one_config(TargetCity.MOSCOW.value)
+        assert config.get("enabled", False) is False
+
+
+class TestSaveGuests:
+    """Tests for saving guests to database"""
+
+    def setup_method(self):
+        self.mock_collection = AsyncMock()
+        self.mock_event_logs = AsyncMock()
+
+        mock_db = MagicMock()
+        mock_db.get_collection = MagicMock()
+        mock_db.get_collection.side_effect = lambda name: {
+            "registered_users": self.mock_collection,
+            "event_logs": self.mock_event_logs,
+            "deleted_users": AsyncMock(),
+        }.get(name, AsyncMock())
+
+        self.db_patcher = patch("app.app.get_database", return_value=mock_db)
+        self.db_patcher.start()
+
+        self.app = App(
+            telegram_bot_token="mock_token",
+            payment_phone_number="1234567890",
+            payment_name="Test User",
+        )
+
+    def teardown_method(self):
+        self.db_patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_save_guests(self):
+        """Test saving guests to database"""
+        guests = [
+            GuestInfo(full_name="Иванова Анна", relationship="Супруг(а)", payment_amount=1500),
+        ]
+
+        await self.app.save_guests(123456, TargetCity.PERM_SUMMER_2025.value, guests)
+
+        # Verify update_one was called with correct filter and data
+        self.mock_collection.update_one.assert_called_once()
+        call_args = self.mock_collection.update_one.call_args
+        filter_arg = call_args[0][0]
+        update_arg = call_args[0][1]
+
+        assert filter_arg["user_id"] == 123456
+        assert filter_arg["target_city"] == TargetCity.PERM_SUMMER_2025.value
+        assert "$set" in update_arg
+        assert len(update_arg["$set"]["guests"]) == 1
+        assert update_arg["$set"]["guests"][0]["full_name"] == "Иванова Анна"
+
+    @pytest.mark.asyncio
+    async def test_save_multiple_guests(self):
+        """Test saving multiple guests"""
+        guests = [
+            GuestInfo(full_name="Иванова Анна", relationship="Супруг(а)", payment_amount=1500),
+            GuestInfo(full_name="Петров Петр", relationship="Друг/Подруга", payment_amount=1800),
+        ]
+
+        await self.app.save_guests(123456, TargetCity.PERM_SUMMER_2025.value, guests)
+
+        call_args = self.mock_collection.update_one.call_args
+        update_arg = call_args[0][1]
+        assert len(update_arg["$set"]["guests"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_save_guests_logs_event(self):
+        """Test that saving guests creates an event log"""
+        guests = [
+            GuestInfo(full_name="Иванова Анна", relationship="Супруг(а)", payment_amount=1500),
+        ]
+
+        await self.app.save_guests(123456, TargetCity.PERM_SUMMER_2025.value, guests)
+
+        # Verify event log was created
+        self.mock_event_logs.insert_one.assert_called_once()
+        log_entry = self.mock_event_logs.insert_one.call_args[0][0]
+        assert log_entry["event_type"] == "guests_added"
+        assert log_entry["data"]["guest_count"] == 1
+
+
+class TestSaveRegisteredUserWithGuests:
+    """Tests for saving registered user with guests"""
+
+    def setup_method(self):
+        self.mock_collection = AsyncMock()
+        self.mock_event_logs = AsyncMock()
+
+        mock_db = MagicMock()
+        mock_db.get_collection = MagicMock()
+        mock_db.get_collection.side_effect = lambda name: {
+            "registered_users": self.mock_collection,
+            "event_logs": self.mock_event_logs,
+            "deleted_users": AsyncMock(),
+        }.get(name, AsyncMock())
+
+        self.db_patcher = patch("app.app.get_database", return_value=mock_db)
+        self.db_patcher.start()
+
+        self.app = App(
+            telegram_bot_token="mock_token",
+            payment_phone_number="1234567890",
+            payment_name="Test User",
+        )
+
+    def teardown_method(self):
+        self.db_patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_save_user_with_guests(self):
+        """Test saving a user with guests persists the guests list"""
+        guests = [
+            GuestInfo(full_name="Иванова Анна", relationship="Супруг(а)", payment_amount=1500),
+        ]
+        user = RegisteredUser(
+            full_name="Иванов Иван",
+            graduation_year=2010,
+            class_letter="А",
+            target_city=TargetCity.PERM_SUMMER_2025,
+            guests=guests,
+        )
+
+        # No existing registration
+        self.mock_collection.find_one.return_value = None
+
+        await self.app.save_registered_user(user, user_id=123456, username="test_user")
+
+        # Verify insert_one was called
+        self.mock_collection.insert_one.assert_called_once()
+        inserted_data = self.mock_collection.insert_one.call_args[0][0]
+
+        assert "guests" in inserted_data
+        assert len(inserted_data["guests"]) == 1
+        assert inserted_data["guests"][0]["full_name"] == "Иванова Анна"
+        assert inserted_data["guests"][0]["payment_amount"] == 1500


### PR DESCRIPTION
## Summary

This PR adds support for registrants to bring additional guests (plus-ones) to events. Guests are stored as a nested list within each registration document, with admin-configurable pricing strategies and per-event guest limits.

## Key Changes

### Data Model
- Added `GuestInfo` model with fields for guest name, relationship, and payment amount
- Added `PlusOnePricingStrategy` enum supporting two strategies:
  - `SAME_AS_REGISTRANT`: Guest pays the same as the registrant
  - `SAME_WITH_MINIMUM`: Guest pays the registrant's price or a configured minimum, whichever is higher
- Extended `RegisteredUser` model with optional `guests` list field

### Registration Flow
- Added guest collection flow in the registration process that:
  - Prompts users to add guests (if enabled for their event)
  - Validates guest names using the same Russian name validation as registrants
  - Collects guest relationship via inline buttons with free-text fallback
  - Calculates guest pricing based on the event's configured strategy
  - Allows adding multiple guests up to the event's configured maximum
- Guests are saved to the database after collection and before payment processing

### Payment & Admin Features
- Updated payment messages to show itemized breakdown including guest costs
- Modified admin payment validation messages to display guest details
- Added guest information to user registration info displays
- Updated statistics to include guest counts and total people (registrants + guests)

### Data Export
- Extended CSV and Google Sheets exports with guest-related columns:
  - Guest count per registration
  - Guest details (name, relationship, individual price)
  - Total payment for all guests

### Configuration
- Added `PLUS_ONE_CONFIG` dictionary in `App` class to manage per-event guest settings
- Currently enabled for `PERM_SUMMER_2025` with max 2 guests and 1500₽ minimum price
- Other events default to disabled plus-one support

### Database Operations
- Added `save_guests()` method to persist guest lists
- Added `get_plus_one_config()` and `calculate_guest_price()` helper methods
- Guest data stored as nested documents within registration records

## Testing
- Comprehensive test suite covering:
  - Guest model creation and serialization
  - Both pricing strategies with various price scenarios
  - Configuration retrieval for enabled/disabled cities
  - Database persistence of guests
  - Integration with user registration workflow

https://claude.ai/code/session_01LzvAAfmK7ymHT6ydmosSkS