### PR TITLE
Fix payment misattribution, early bird inclusivity, and duplicate click protection

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -336,7 +336,7 @@ class App:
             early_bird_deadline = event.get("early_bird_deadline")
             if (
                 early_bird_deadline
-                and datetime.now() < early_bird_deadline
+                and datetime.now().date() <= early_bird_deadline.date()
                 and early_bird_discount > 0
             ):
                 discount = early_bird_discount
@@ -366,7 +366,7 @@ class App:
         early_bird_deadline = event.get("early_bird_deadline")
         if (
             early_bird_deadline
-            and datetime.now() < early_bird_deadline
+            and datetime.now().date() <= early_bird_deadline.date()
             and early_bird_discount > 0
         ):
             discounted_price = max(0, regular_price - early_bird_discount)

--- a/src/router.py
+++ b/src/router.py
@@ -242,7 +242,7 @@ async def handle_registered_user(
             await process_payment(
                 message,
                 state,
-                city,
+                reg["event_id"],
                 graduation_year,
                 skip_instructions,
                 graduate_type=graduate_type,

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -119,12 +119,6 @@ async def process_payment(
     logger.info(f"Using original user information: ID={user_id}, username={username}")
     assert user_id is not None, "user_id must be resolved before processing payment"
 
-    # Get user registration to get graduate_type
-    if user_id:
-        registration = await app.get_user_registration(user_id)
-        if registration and "graduate_type" in registration:
-            graduate_type = registration["graduate_type"]
-
     # Load event from registration
     registration_data = await app.collection.find_one(
         {"user_id": user_id, "event_id": event_id}
@@ -132,6 +126,9 @@ async def process_payment(
     event = None
     if registration_data:
         event = await app.get_event_for_registration(registration_data)
+        # Get graduate_type from the correct registration
+        if "graduate_type" in registration_data:
+            graduate_type = registration_data["graduate_type"]
 
     # Calculate payment amount from event config
     if event:
@@ -223,7 +220,7 @@ async def process_payment(
         today = datetime.now()
         is_early = (
             early_bird_deadline
-            and today < early_bird_deadline
+            and today.date() <= early_bird_deadline.date()
             and early_bird_discount_amount > 0
         )
 
@@ -485,8 +482,8 @@ async def process_payment(
             else:
                 user_info += f"💰 Сумма к оплате: {needs_to_pay}\n"
 
-            # Get user registration for additional info
-            user_registration = await app.get_user_registration(user_id)
+            # Get user registration for additional info (use event-specific lookup)
+            user_registration = await app.collection.find_one({"user_id": user_id, "event_id": event_id})
             if user_registration:
                 user_info += (
                     f"👤 ФИО: {user_registration.get('full_name', 'Неизвестно')}\n"
@@ -722,7 +719,7 @@ async def pay_handler(message: Message, state: FSMContext):
     user_id = message.from_user.id
 
     # Check if user is registered
-    registrations = await app.get_user_registrations(user_id)
+    registrations = await app.get_user_active_registrations(user_id)
 
     if not registrations:
         await send_safe(
@@ -856,9 +853,17 @@ async def confirm_payment_callback(callback_query: CallbackQuery, state: FSMCont
     if event_id in _LEGACY_CITY_CODES_REVERSE:
         city = _LEGACY_CITY_CODES_REVERSE[event_id]
         logger.warning(f"Legacy callback format, resolved city: {city}")
-        registration = await app.collection.find_one(
-            {"user_id": user_id, "target_city": city}
-        )
+        # Find all registrations for user+city, prefer non-archived event
+        cursor = app.collection.find({"user_id": user_id, "target_city": city})
+        candidates = await cursor.to_list(length=None)
+        registration = None
+        for candidate in candidates:
+            evt = await app.get_event_for_registration(candidate)
+            if evt and evt.get("status") != "archived":
+                registration = candidate
+                break
+        if not registration and candidates:
+            registration = candidates[0]
     else:
         logger.info(
             f"Processing payment confirmation: user_id={user_id}, event_id={event_id}"
@@ -889,6 +894,17 @@ async def confirm_payment_callback(callback_query: CallbackQuery, state: FSMCont
 
     assert callback_query.message is not None, "callback_query.message is None"
     chat_id = callback_query.message.chat.id
+
+    # Immediately remove inline buttons to prevent duplicate clicks
+    try:
+        await callback_query.message.edit_reply_markup(reply_markup=None)
+    except Exception:
+        # If buttons are already removed, this is a duplicate click — ignore
+        logger.warning(
+            f"Duplicate payment confirmation attempt for user {user_id}, event {event_id}"
+        )
+        await callback_query.answer("Этот платеж уже обрабатывается")
+        return
 
     # Handle different amount cases
     if amount_str == "custom" or not amount_str:
@@ -1015,13 +1031,13 @@ async def confirm_payment_callback(callback_query: CallbackQuery, state: FSMCont
                 new_caption = new_caption[-1024:]
 
             await callback_query.message.edit_caption(  # type: ignore[union-attr]
-                caption=new_caption, reply_markup=None
+                caption=new_caption
             )
         else:
             text = callback_query.message.text or ""  # type: ignore[union-attr]
             new_text = f"{text}\n\n{payment_status} для {user_info}"
 
-            await callback_query.message.edit_text(text=new_text, reply_markup=None)  # type: ignore[union-attr]
+            await callback_query.message.edit_text(text=new_text)  # type: ignore[union-attr]
 
     # Confirm to admin with a brief notification
     await callback_query.answer("Платеж подтвержден")
@@ -1052,9 +1068,17 @@ async def decline_payment_callback(callback_query: CallbackQuery, state: FSMCont
     if event_id in _LEGACY_CITY_CODES_REVERSE:
         city = _LEGACY_CITY_CODES_REVERSE[event_id]
         logger.warning(f"Legacy callback format, resolved city: {city}")
-        registration = await app.collection.find_one(
-            {"user_id": user_id, "target_city": city}
-        )
+        # Find all registrations for user+city, prefer non-archived event
+        cursor = app.collection.find({"user_id": user_id, "target_city": city})
+        candidates = await cursor.to_list(length=None)
+        registration = None
+        for candidate in candidates:
+            evt = await app.get_event_for_registration(candidate)
+            if evt and evt.get("status") != "archived":
+                registration = candidate
+                break
+        if not registration and candidates:
+            registration = candidates[0]
         event_id = registration.get("event_id", event_id) if registration else event_id
     else:
         logger.info(

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -45,6 +45,7 @@ def mock_app():
     with patch("src.routers.payment.app") as mock_app:
         # Configure src mocks with AsyncMock for async methods
         mock_app.get_user_registrations = AsyncMock(return_value=[])
+        mock_app.get_user_active_registrations = AsyncMock(return_value=[])
         mock_app.get_user_registration = AsyncMock(return_value=None)
         mock_app.save_payment_info = AsyncMock()
         mock_app.update_payment_status = AsyncMock()
@@ -154,7 +155,7 @@ async def test_pay_handler_no_registrations(
     mock_message, mock_state, mock_app, mock_send_safe
 ):
     # Configure the mock for a user with no registrations
-    mock_app.get_user_registrations.return_value = []
+    mock_app.get_user_active_registrations.return_value = []
     from src.routers.payment import (
         pay_handler,
     )
@@ -186,7 +187,11 @@ async def test_pay_handler_with_registration(
         "event_id": "aabbccddeeff00112233aabb",
         "graduate_type": GraduateType.GRADUATE.value,
     }
-    mock_app.get_user_registrations.return_value = [mock_registration]
+    mock_app.get_user_active_registrations.return_value = [mock_registration]
+
+    # Mock event lookup for is_event_free check
+    mock_event = {"pricing_type": "formula", "free_for_types": []}
+    mock_app.get_event_for_registration = AsyncMock(return_value=mock_event)
 
     # Mock the process_payment function
     with patch("src.routers.payment.process_payment") as mock_process:


### PR DESCRIPTION
- Fix critical bug: /start pay flow passed city name instead of event_id to process_payment (router.py:245), causing payments to fail or land on wrong record
- Fix /pay showing archived events: use get_user_active_registrations instead of get_user_registrations, preventing users from accidentally paying for old events
- Fix legacy city-code fallback to prefer non-archived registrations when multiple exist for same city (confirm + decline callbacks)
- Fix get_user_registration returning wrong record: use event-specific lookups in process_payment for graduate_type and user_info display
- Make early bird discount inclusive of deadline date (<=  instead of <)
- Add duplicate click protection: immediately remove inline buttons on confirm