### PR TITLE
Add confirmed-payment entry ticket cards

### DIFF
--- a/docs/paid-ticket-contract.md
+++ b/docs/paid-ticket-contract.md
@@ -21,7 +21,7 @@ must return these fields:
 {
   "schema_version": 1,
   "payment_status": "confirmed",
-  "payment_kind": "event_attendance_donation",
+  "payment_kind": "event_attendance_payment",
   "bot_registration_id": "Mongo registered_users._id",
   "telegram_user_id": 123456789,
   "bot_event_id": "Mongo events._id",
@@ -70,6 +70,10 @@ Bot validation before writing `confirmed`:
    prefers it over the transitional visual code.
 7. Every `ticket_verification_url` must be HTTPS and contain a signed, revocable,
    non-personal token. Add it as a QR code in a later additive slice.
+8. `payment_kind` remains the accounting-neutral `event_attendance_payment`.
+   Petr calls this a donation in user-facing copy, but it must not enter generic
+   donation, endowment, or fundraising totals until Club 146 accounting confirms
+   its classification.
 
 The intent-creation request from bot to website needs the same three binding
 IDs (`bot_registration_id`, `telegram_user_id`, `bot_event_id`),

--- a/docs/paid-ticket-contract.md
+++ b/docs/paid-ticket-contract.md
@@ -1,0 +1,78 @@
+# Paid entry ticket contract
+
+Current TEST-first gate:
+
+- The bot sends/resends a personalized card only when the matching Mongo
+  registration has the exact value `payment_status == "confirmed"`.
+- `pending`, `declined`, missing status, and legacy unpaid strings never receive
+  a card.
+- `/status` is the recovery path. The existing admin receipt-confirmation path
+  sends the card immediately and `/status` can resend it later.
+- The fallback `146-XXXX-XXXX-XXXX` code is derived deterministically from the
+  bot registration ID, bot event ID, and Telegram user ID. It is a visual
+  registration reference, not cryptographic proof. Door staff must pair it
+  with the person's name and the bot's confirmed-registration list.
+
+The website payment bridge can be added without changing the renderer. After a
+signed CloudPayments webhook becomes authoritative, its bot-facing status API
+must return these fields:
+
+```json
+{
+  "schema_version": 1,
+  "payment_status": "confirmed",
+  "payment_kind": "event_attendance_donation",
+  "bot_registration_id": "Mongo registered_users._id",
+  "telegram_user_id": 123456789,
+  "bot_event_id": "Mongo events._id",
+  "website_event_uid": "stable Event.uid",
+  "amount_minor": 250000,
+  "currency": "RUB",
+  "paid_at": "2026-07-20T12:34:56Z",
+  "provider_payment_id": "opaque provider transaction id",
+  "admissions": [
+    {
+      "admission_id": "stable opaque id",
+      "role": "registrant",
+      "display_name": "Лавров Петр",
+      "ticket_code": "opaque uppercase code",
+      "ticket_verification_url": "https://146.school/tickets/verify/opaque-token"
+    },
+    {
+      "admission_id": "stable opaque id for guest 1",
+      "role": "guest",
+      "guest_index": 0,
+      "display_name": "Имя гостя",
+      "ticket_code": "different opaque uppercase code",
+      "ticket_verification_url": "https://146.school/tickets/verify/another-token"
+    }
+  ]
+}
+```
+
+Bot validation before writing `confirmed`:
+
+1. `bot_registration_id`, `telegram_user_id`, and `bot_event_id` must all match
+   one existing registration; never match by name, username, or email.
+2. `website_event_uid` must equal the bot event's future
+   `website_event_uid` field.
+3. Amount/currency must equal the immutable payment intent; browser-return
+   query parameters are never authoritative.
+4. `provider_payment_id` must be idempotent. A repeated webhook/status response
+   must not add payment twice or issue a second ticket.
+5. Only `payment_status: confirmed` unlocks admission. The website returns one
+   `admissions` item per human: registrant plus each named guest. Admission IDs
+   and ticket codes must be distinct so check-in, attendance, and later profile
+   achievements remain person-specific.
+6. For the immediate pre-website bridge, the bot renders one group-style card
+   containing the registrant and up to three current guest names. The bot stores
+   a future primary `ticket_code` on the registration; the renderer automatically
+   prefers it over the transitional visual code.
+7. Every `ticket_verification_url` must be HTTPS and contain a signed, revocable,
+   non-personal token. Add it as a QR code in a later additive slice.
+
+The intent-creation request from bot to website needs the same three binding
+IDs (`bot_registration_id`, `telegram_user_id`, `bot_event_id`),
+`website_event_uid`, immutable `amount_minor`/`currency`, attendee name, and an
+email only if CloudPayments requires it. Event, amount, purpose, and payment
+frequency must not be editable through public URL parameters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "python-dotenv",
     "pydantic>=2.10.6",
     "pydantic-settings>=2.7.1",
+    "pillow>=12.1.1,<13",
     # Data visualization
     "matplotlib>=3.8.3",
     "seaborn>=0.13.1",

--- a/src/router.py
+++ b/src/router.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional
 from src.app import App, RegisteredUser, GraduateType, PAYMENT_STATUS_MAP
 from src.event_images import send_event_image
 from src.routers.admin import admin_handler
+from src.ticket_cards import is_ticket_unlocked, send_paid_ticket_card
 from botspot import commands_menu
 from src.user_interactions import ask_user, ask_user_choice
 from botspot.utils import send_safe, is_admin
@@ -1758,6 +1759,15 @@ def _format_payment_status_line(reg: Dict, event, graduate_type: str) -> str:
     return line
 
 
+def _format_ticket_status_line(reg: Dict) -> str:
+    if is_ticket_unlocked(reg):
+        return "🎟 Именной билет действителен для входа и доступен ниже.\n"
+    return (
+        "🎟 Заявка сохранена; действующего билета пока нет. "
+        "Именной билет появится после подтверждения оплаты.\n"
+    )
+
+
 def _format_registration_status_text(registrations, events_by_reg, app: App) -> str:
     status_text = "📋 Ваши регистрации:\n\n"
     for reg, event in zip(registrations, events_by_reg):
@@ -1781,6 +1791,7 @@ def _format_registration_status_text(registrations, events_by_reg, app: App) -> 
             )
 
         status_text += _format_payment_status_line(reg, event, graduate_type)
+        status_text += _format_ticket_status_line(reg)
         status_text += "\n"
     return status_text
 
@@ -1827,6 +1838,10 @@ async def status_handler(message: Message, state: FSMContext, app: App):
         status_text += "Следите за новостями в группе школы, чтобы не пропустить следующие встречи."
 
     await send_safe(message.chat.id, status_text, reply_markup=ReplyKeyboardRemove())
+
+    for registration, event in zip(registrations, events_by_reg):
+        if is_ticket_unlocked(registration):
+            await send_paid_ticket_card(message.chat.id, registration, event)
 
 
 async def _status_no_registrations(message: Message, app: App):

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -281,7 +281,8 @@ async def admin_register_payment(message: Message, state: FSMContext, app: App):
             bot = get_dependency_manager().bot
             await bot.send_message(
                 int(target_user_id),
-                f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!",
+                f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!\n"
+                "Именной билет доступен по команде /status.",
             )
         except Exception as e:
             logger.warning(f"Could not notify user {target_user_id}: {e}")

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import Optional
+from typing import Mapping, Optional
 
 from aiogram import Router
 from aiogram.filters import Command
@@ -12,6 +12,7 @@ from litellm import acompletion
 from loguru import logger
 from pydantic import BaseModel
 from src.app import App
+from src.ticket_cards import send_paid_ticket_card
 from botspot import commands_menu
 from botspot.components.qol.bot_commands_menu import Visibility
 from src.user_interactions import ask_user_choice, ask_user_raw
@@ -247,6 +248,29 @@ async def _confirm_payment_amount(
         return None
 
 
+async def _send_admin_confirmed_ticket(
+    app: App, target_user_id: int, event_id: str
+) -> None:
+    """Re-read authoritative state and attempt ticket delivery without blocking payment."""
+
+    try:
+        registration = await app.collection.find_one(
+            {"user_id": target_user_id, "event_id": event_id}
+        )
+        if not isinstance(registration, Mapping):
+            logger.warning(
+                f"Could not re-read registration for ticket delivery: "
+                f"user={target_user_id}, event={event_id}"
+            )
+            return
+        event = await app.get_event_for_registration(registration)
+        await send_paid_ticket_card(target_user_id, registration, event)
+    except Exception as e:
+        logger.warning(
+            f"Could not deliver confirmed ticket for user {target_user_id}: {e}"
+        )
+
+
 async def admin_register_payment(message: Message, state: FSMContext, app: App):
     """Admin flow: select event → pick unpaid user → confirm payment."""
     chat_id = message.chat.id
@@ -282,10 +306,13 @@ async def admin_register_payment(message: Message, state: FSMContext, app: App):
             await bot.send_message(
                 int(target_user_id),
                 f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!\n"
-                "Именной билет доступен по команде /status.",
+                "Именной билет отправляем следующим сообщением. "
+                "Если он не появится, откройте /status.",
             )
         except Exception as e:
             logger.warning(f"Could not notify user {target_user_id}: {e}")
+
+        await _send_admin_confirmed_ticket(app, int(target_user_id), selected)
     else:
         # No user_id — update by registration _id
         await app.collection.update_one(

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -19,6 +19,7 @@ from src import templates
 from src.app import App, GraduateType
 from src.router import is_admin, commands_menu, get_event_date_display
 from src.routers.admin import PaymentInfo
+from src.ticket_cards import send_paid_ticket_card
 from src.user_interactions import ask_user_raw, ask_user_choice, ask_user_choice_raw
 from botspot.utils import send_safe
 
@@ -1346,6 +1347,9 @@ async def confirm_payment_callback(callback_query: CallbackQuery, state: FSMCont
         payment_message += "Если у вас будет возможность, вы можете доплатить эту сумму позже, используя команду /pay."
 
     await send_safe(user_id, payment_message)
+
+    event = await app.get_event_for_registration(updated_registration)
+    await send_paid_ticket_card(user_id, updated_registration, event)
 
     if callback_query.message:
         user_info = f"{registration.get('username', user_id)} ({registration.get('full_name', 'Неизвестно')})"

--- a/src/ticket_cards.py
+++ b/src/ticket_cards.py
@@ -1,0 +1,365 @@
+"""Deterministic personalized entry cards for confirmed registrations."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import re
+from datetime import date, datetime
+from functools import lru_cache
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Mapping
+
+from aiogram.types import BufferedInputFile
+from PIL import Image, ImageDraw, ImageFont
+from pydantic import BaseModel, Field
+
+from botspot.core.dependency_manager import get_dependency_manager
+from botspot.utils.internal import get_logger
+
+
+logger = get_logger()
+
+CARD_SIZE = (1200, 760)
+_TICKET_CODE_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9-]{7,39}$")
+
+
+class TicketCardError(ValueError):
+    """Raised when a registration must not receive an entry card."""
+
+
+class TicketCardData(BaseModel):
+    """Validated display data; no payment-provider secrets are rendered."""
+
+    full_name: str = Field(min_length=1, max_length=160)
+    graduate_label: str = Field(min_length=1, max_length=80)
+    event_name: str = Field(min_length=1, max_length=160)
+    event_date: str = Field(min_length=1, max_length=80)
+    event_time: str = Field(min_length=1, max_length=40)
+    venue: str = Field(min_length=1, max_length=160)
+    address: str = Field(min_length=1, max_length=240)
+    guest_names: list[str] = Field(default_factory=list, max_length=3)
+    ticket_code: str = Field(pattern=_TICKET_CODE_PATTERN.pattern)
+
+
+class TicketCardArtifact(BaseModel):
+    """Telegram-ready deterministic PNG plus its user-facing metadata."""
+
+    image: bytes
+    filename: str
+    caption: str
+    ticket_code: str
+
+
+def is_ticket_unlocked(registration: Mapping[str, Any]) -> bool:
+    """The current bot contract: only exact confirmed status unlocks entry."""
+
+    return registration.get("payment_status") == "confirmed"
+
+
+def _clean_text(value: Any, default: str, max_length: int) -> str:
+    text = " ".join(str(value or "").split())
+    return (text or default)[:max_length]
+
+
+def _object_id(value: Any, field: str) -> str:
+    text = _clean_text(value, "", 160)
+    if not text:
+        raise TicketCardError(f"Missing {field}")
+    return text
+
+
+def _event_date_display(event: Mapping[str, Any]) -> str:
+    displayed = _clean_text(event.get("date_display"), "", 80)
+    if displayed:
+        return displayed
+
+    value = event.get("date")
+    if isinstance(value, datetime | date):
+        return value.strftime("%d.%m.%Y")
+    return "Дата уточняется"
+
+
+def _graduate_label(registration: Mapping[str, Any]) -> str:
+    graduate_type = registration.get("graduate_type", "GRADUATE")
+    if graduate_type == "TEACHER":
+        return "Учитель"
+    if graduate_type == "ORGANIZER":
+        return "Организатор"
+    if graduate_type == "NON_GRADUATE":
+        return "Друг школы"
+
+    year = _clean_text(registration.get("graduation_year"), "", 8)
+    class_letter = _clean_text(registration.get("class_letter"), "", 12)
+    if year and class_letter:
+        return f"Выпуск {year} • класс {class_letter}"
+    if year:
+        return f"Выпуск {year}"
+    return "Выпускник школы 146"
+
+
+def _guest_names(registration: Mapping[str, Any]) -> list[str]:
+    raw_guests = registration.get("guests") or []
+    if not isinstance(raw_guests, list):
+        raise TicketCardError("Registration guests must be a list")
+    if len(raw_guests) > 3:
+        raise TicketCardError("Entry card supports at most three registered guests")
+
+    names: list[str] = []
+    for guest in raw_guests:
+        if not isinstance(guest, Mapping):
+            raise TicketCardError("Each guest must be a named registration record")
+        name = _clean_text(guest.get("name"), "", 80)
+        if not name:
+            raise TicketCardError("Each guest must have a name")
+        names.append(name)
+    return names
+
+
+def _ticket_code(registration: Mapping[str, Any], event_id: str) -> str:
+    """Use a future website code when present; otherwise make a stable visual ID.
+
+    The derived fallback is deliberately only a visual registration reference,
+    not a cryptographic proof. A website-issued opaque code can be written to
+    ``ticket_code`` later without changing rendering or `/status` delivery.
+    """
+
+    explicit = registration.get("ticket_code")
+    if explicit is not None:
+        code = _clean_text(explicit, "", 40)
+        if not _TICKET_CODE_PATTERN.fullmatch(code):
+            raise TicketCardError("Invalid website-issued ticket_code")
+        return code
+
+    registration_id = _object_id(registration.get("_id"), "registration _id")
+    user_id = _object_id(registration.get("user_id"), "Telegram user_id")
+    payload = f"ticket-card-v1|{registration_id}|{event_id}|{user_id}".encode()
+    digest = hashlib.sha256(payload).hexdigest().upper()[:12]
+    return f"146-{digest[:4]}-{digest[4:8]}-{digest[8:]}"
+
+
+def build_ticket_card_data(
+    registration: Mapping[str, Any], event: Mapping[str, Any] | None
+) -> TicketCardData:
+    """Build a card only when registration, person, and event bindings agree."""
+
+    if not is_ticket_unlocked(registration):
+        raise TicketCardError("Entry card requires payment_status == confirmed")
+    if event is None:
+        raise TicketCardError("Entry card requires an event")
+
+    registration_event_id = _object_id(registration.get("event_id"), "event_id")
+    event_id = _object_id(event.get("_id"), "event _id")
+    if registration_event_id != event_id:
+        raise TicketCardError("Registration event_id does not match the event")
+
+    return TicketCardData(
+        full_name=_clean_text(registration.get("full_name"), "", 160),
+        graduate_label=_graduate_label(registration),
+        event_name=_clean_text(
+            event.get("name") or event.get("title"), "Мероприятие клуба 146", 160
+        ),
+        event_date=_event_date_display(event),
+        event_time=_clean_text(event.get("time_display"), "Время уточняется", 40),
+        venue=_clean_text(event.get("venue"), "Место уточняется", 160),
+        address=_clean_text(event.get("address"), "Адрес уточняется", 240),
+        guest_names=_guest_names(registration),
+        ticket_code=_ticket_code(registration, event_id),
+    )
+
+
+@lru_cache(maxsize=2)
+def _font_path(bold: bool) -> Path:
+    """Use Matplotlib's bundled DejaVu font on every deployment platform."""
+
+    spec = importlib.util.find_spec("matplotlib")
+    if spec is None or not spec.submodule_search_locations:
+        raise TicketCardError("Matplotlib's bundled ticket font is unavailable")
+    filename = "DejaVuSans-Bold.ttf" if bold else "DejaVuSans.ttf"
+    path = (
+        Path(next(iter(spec.submodule_search_locations)))
+        / "mpl-data/fonts/ttf"
+        / filename
+    )
+    if not path.is_file():
+        raise TicketCardError("Matplotlib's bundled ticket font is unavailable")
+    return path
+
+
+@lru_cache(maxsize=64)
+def _font(size: int, *, bold: bool = False) -> ImageFont.FreeTypeFont:
+    return ImageFont.truetype(_font_path(bold), size=size)
+
+
+def _fit_font(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    max_width: int,
+    preferred_size: int,
+    minimum_size: int,
+):
+    for size in range(preferred_size, minimum_size - 1, -2):
+        font = _font(size)
+        box = draw.textbbox((0, 0), text, font=font)
+        if box[2] - box[0] <= max_width:
+            return font
+    return _font(minimum_size)
+
+
+def _ellipsize(draw: ImageDraw.ImageDraw, text: str, font, max_width: int) -> str:
+    if draw.textbbox((0, 0), text, font=font)[2] <= max_width:
+        return text
+    shortened = text
+    while shortened:
+        candidate = shortened.rstrip() + "…"
+        if draw.textbbox((0, 0), candidate, font=font)[2] <= max_width:
+            return candidate
+        shortened = shortened[:-1]
+    return "…"
+
+
+def _wrap_lines(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    font,
+    max_width: int,
+    max_lines: int,
+) -> list[str]:
+    words = text.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if not current or draw.textbbox((0, 0), candidate, font=font)[2] <= max_width:
+            current = candidate
+            continue
+        lines.append(_ellipsize(draw, current, font, max_width))
+        current = word
+        if len(lines) == max_lines - 1:
+            break
+    if current and len(lines) < max_lines:
+        remaining_start = len(" ".join(lines + [current]).split())
+        remaining = " ".join(words[remaining_start:])
+        final = f"{current} {remaining}".strip()
+        lines.append(_ellipsize(draw, final, font, max_width))
+    return lines or [""]
+
+
+def render_ticket_card(data: TicketCardData) -> bytes:
+    """Render the same validated input to byte-identical PNG output."""
+
+    image = Image.new("RGB", CARD_SIZE, "#0B2433")
+    draw = ImageDraw.Draw(image)
+
+    draw.rounded_rectangle((28, 28, 1172, 732), radius=34, fill="#F7F2E8")
+    draw.rounded_rectangle((28, 28, 1172, 124), radius=34, fill="#143F56")
+    draw.rectangle((28, 88, 1172, 124), fill="#143F56")
+    draw.text(
+        (68, 57),
+        "КЛУБ ДРУЗЕЙ ШКОЛЫ 146",
+        font=_font(34, bold=True),
+        fill="#FFFFFF",
+    )
+    draw.rounded_rectangle((969, 49, 1125, 103), radius=18, fill="#F0AA36")
+    draw.text((1011, 62), "ВХОД", font=_font(25, bold=True), fill="#152A35")
+
+    draw.text(
+        (68, 154),
+        "ИМЕННОЙ БИЛЕТ • БЕЙДЖ",
+        font=_font(30, bold=True),
+        fill="#B46B14",
+    )
+    name_font = _fit_font(draw, data.full_name, 1060, 68, 38)
+    name = _ellipsize(draw, data.full_name, name_font, 1060)
+    draw.text((68, 210), name, font=name_font, fill="#102E3D")
+    draw.text((71, 302), data.graduate_label, font=_font(30), fill="#4E6671")
+
+    details_top = 365
+    if data.guest_names:
+        guests = f"С вами: {', '.join(data.guest_names)}"
+        guests_font = _fit_font(draw, guests, 1060, 24, 19)
+        guests = _ellipsize(draw, guests, guests_font, 1060)
+        draw.text((71, 342), guests, font=guests_font, fill="#4E6671")
+        details_top = 390
+
+    draw.line((68, details_top, 1132, details_top), fill="#C8D1D2", width=3)
+    event_font = _fit_font(draw, data.event_name, 1060, 40, 28)
+    event_name = _ellipsize(draw, data.event_name, event_font, 1060)
+    draw.text((68, details_top + 32), event_name, font=event_font, fill="#102E3D")
+    draw.text(
+        (68, details_top + 97),
+        f"{data.event_date} • {data.event_time}",
+        font=_font(30),
+        fill="#143F56",
+    )
+
+    details_font = _font(25)
+    place = f"{data.venue} • {data.address}"
+    for index, line in enumerate(
+        _wrap_lines(draw, place, details_font, 1060, max_lines=2)
+    ):
+        draw.text(
+            (68, details_top + 151 + index * 38),
+            line,
+            font=details_font,
+            fill="#4E6671",
+        )
+
+    draw.rounded_rectangle((68, 636, 570, 698), radius=18, fill="#DCE8E4")
+    draw.text(
+        (91, 650),
+        "ОПЛАТА ПОДТВЕРЖДЕНА",
+        font=_font(26, bold=True),
+        fill="#176747",
+    )
+    code_label = f"КОД: {data.ticket_code}"
+    code_font = _fit_font(draw, code_label, 510, 27, 20)
+    draw.text((622, 652), code_label, font=code_font, fill="#143F56")
+
+    output = BytesIO()
+    image.save(output, format="PNG", optimize=False, compress_level=9)
+    return output.getvalue()
+
+
+def make_ticket_card(
+    registration: Mapping[str, Any], event: Mapping[str, Any] | None
+) -> TicketCardArtifact:
+    """Build the Telegram artifact after enforcing the confirmed-payment gate."""
+
+    data = build_ticket_card_data(registration, event)
+    return TicketCardArtifact(
+        image=render_ticket_card(data),
+        filename=f"club-146-ticket-{data.ticket_code}.png",
+        caption=(
+            "🎟 Ваш именной билет и бейдж. "
+            "Покажите эту карточку на входе.\n"
+            f"Код: {data.ticket_code}"
+        ),
+        ticket_code=data.ticket_code,
+    )
+
+
+async def send_paid_ticket_card(
+    chat_id: int,
+    registration: Mapping[str, Any],
+    event: Mapping[str, Any] | None,
+) -> bool:
+    """Send a confirmed card; unpaid/invalid data fails closed without a send."""
+
+    if not is_ticket_unlocked(registration):
+        return False
+
+    try:
+        artifact = make_ticket_card(registration, event)
+        bot = get_dependency_manager().bot
+        await bot.send_photo(
+            chat_id=chat_id,
+            photo=BufferedInputFile(artifact.image, filename=artifact.filename),
+            caption=artifact.caption,
+            parse_mode=None,
+        )
+    except Exception as exc:
+        logger.warning(f"Could not send paid ticket card: {exc}")
+        return False
+    return True

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -363,6 +363,57 @@ async def test_admin_register_payment_select_user_and_confirm(
 
 
 @pytest.mark.asyncio
+async def test_admin_register_payment_rereads_and_sends_confirmed_ticket(
+    mock_message, mock_state, mock_app, mock_send_safe
+):
+    """The separate admin flow sends the ticket from authoritative updated state."""
+
+    event = _make_event()
+    event_id = str(event["_id"])
+    unpaid = _make_unpaid_user(user_id=111, username="alice", full_name="Алиса")
+    confirmed = {
+        **unpaid,
+        "event_id": event_id,
+        "payment_status": "confirmed",
+        "payment_amount": 2000,
+    }
+    mock_app.get_all_events.return_value = [event]
+    mock_app.get_unpaid_users.return_value = [unpaid]
+    mock_app.collection.find_one.return_value = confirmed
+    mock_app.get_event_for_registration.return_value = event
+
+    choices = iter([event_id, "111"])
+
+    async def choose(*args, **kwargs):
+        return next(choices)
+
+    with (
+        patch(
+            "src.routers.admin.ask_user_choice",
+            new_callable=AsyncMock,
+            side_effect=choose,
+        ),
+        patch(
+            "src.routers.admin.ask_user_raw",
+            new_callable=AsyncMock,
+            return_value="2000",
+        ),
+        patch("botspot.core.dependency_manager.get_dependency_manager") as mock_deps,
+        patch(
+            "src.routers.admin.send_paid_ticket_card", new_callable=AsyncMock
+        ) as send_ticket,
+    ):
+        mock_deps.return_value.bot = AsyncMock()
+        await admin_register_payment(mock_message, mock_state, mock_app)
+
+    mock_app.collection.find_one.assert_awaited_once_with(
+        {"user_id": 111, "event_id": event_id}
+    )
+    mock_app.get_event_for_registration.assert_awaited_once_with(confirmed)
+    send_ticket.assert_awaited_once_with(111, confirmed, event)
+
+
+@pytest.mark.asyncio
 async def test_admin_register_payment_manual_username_found(
     mock_message, mock_state, mock_app, mock_send_safe
 ):
@@ -416,7 +467,7 @@ async def test_admin_register_payment_manual_username_found(
         await admin_register_payment(mock_message, mock_state, mock_app)
 
     # Verify find_one called with stripped username
-    mock_app.collection.find_one.assert_called_once_with(
+    mock_app.collection.find_one.assert_any_await(
         {"username": "vasya", "event_id": eid}
     )
     mock_app.update_payment_status.assert_called_once_with(
@@ -752,7 +803,7 @@ async def test_admin_register_payment_manual_without_at_sign(
         mock_deps.return_value.bot = mock_bot
         await admin_register_payment(mock_message, mock_state, mock_app)
 
-    mock_app.collection.find_one.assert_called_once_with(
+    mock_app.collection.find_one.assert_any_await(
         {"username": "petya", "event_id": eid}
     )
     mock_app.update_payment_status.assert_called_once()

--- a/tests/test_ticket_cards.py
+++ b/tests/test_ticket_cards.py
@@ -1,0 +1,282 @@
+"""Paid ticket-card gate, rendering, delivery, and `/status` recovery tests."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiogram.types import BufferedInputFile
+from PIL import Image
+
+from src.ticket_cards import (
+    CARD_SIZE,
+    TicketCardError,
+    _font,
+    build_ticket_card_data,
+    is_ticket_unlocked,
+    make_ticket_card,
+    send_paid_ticket_card,
+)
+
+
+EVENT_ID = "6a599a17a37724d81b7eadc3"
+
+
+def _registration(status="confirmed", **updates):
+    registration = {
+        "_id": "6a6011111111111111111111",
+        "user_id": 123456789,
+        "event_id": EVENT_ID,
+        "full_name": "Лавров Петр",
+        "graduate_type": "GRADUATE",
+        "graduation_year": 2007,
+        "class_letter": "А",
+        "payment_status": status,
+        "payment_amount": 2500,
+        "target_city": "Пермь",
+    }
+    registration.update(updates)
+    return registration
+
+
+def _event(**updates):
+    event = {
+        "_id": EVENT_ID,
+        "name": "Летняя встреча выпускников 2026",
+        "city": "Пермь",
+        "date_display": "1 Августа, Сб",
+        "time_display": "18:00",
+        "venue": 'Беседка "Журавушка"',
+        "address": 'г.Пермь, ул. Встречная 28, беседка "Журавушка"',
+        "pricing_type": "formula",
+        "free_for_types": [],
+    }
+    event.update(updates)
+    return event
+
+
+def test_confirmed_registration_renders_deterministic_png():
+    first = make_ticket_card(_registration(), _event())
+    second = make_ticket_card(_registration(), _event())
+
+    assert first == second
+    assert first.ticket_code.startswith("146-")
+    assert sha256(first.image).hexdigest() == sha256(second.image).hexdigest()
+    assert "Лавров" not in first.filename
+
+    image = Image.open(BytesIO(first.image))
+    assert image.format == "PNG"
+    assert image.size == CARD_SIZE
+    assert image.mode == "RGB"
+
+
+def test_ticket_font_is_portable_and_supports_cyrillic():
+    assert _font(24).getname()[0] == "DejaVu Sans"
+
+
+def test_visual_code_is_bound_to_event_registration_and_telegram_user():
+    original = build_ticket_card_data(_registration(), _event()).ticket_code
+    other_user = build_ticket_card_data(
+        _registration(user_id=987654321), _event()
+    ).ticket_code
+    other_registration = build_ticket_card_data(
+        _registration(_id="6a6022222222222222222222"), _event()
+    ).ticket_code
+
+    assert len({original, other_user, other_registration}) == 3
+
+
+def test_immediate_card_lists_up_to_three_named_guests_as_one_group():
+    registration = _registration(
+        guests=[{"name": "Анна"}, {"name": "Борис"}, {"name": "Вера"}]
+    )
+    data = build_ticket_card_data(registration, _event())
+    artifact = make_ticket_card(registration, _event())
+
+    assert data.guest_names == ["Анна", "Борис", "Вера"]
+    assert artifact.image != make_ticket_card(_registration(), _event()).image
+
+
+def test_more_than_three_guests_fails_closed_instead_of_omitting_a_person():
+    registration = _registration(
+        guests=[{"name": f"Гость {index}"} for index in range(4)]
+    )
+    with pytest.raises(TicketCardError, match="at most three"):
+        make_ticket_card(registration, _event())
+
+
+@pytest.mark.parametrize(
+    "status", [None, "not paid", "Не оплачено", "pending", "declined", "paid"]
+)
+def test_unconfirmed_registration_never_unlocks_or_renders(status):
+    registration = _registration(status=status)
+
+    assert is_ticket_unlocked(registration) is False
+    with pytest.raises(TicketCardError, match="payment_status == confirmed"):
+        make_ticket_card(registration, _event())
+
+
+def test_event_binding_mismatch_fails_closed():
+    with pytest.raises(TicketCardError, match="does not match"):
+        make_ticket_card(_registration(), _event(_id="other-event"))
+
+
+def test_future_website_ticket_code_is_additive_and_preferred():
+    artifact = make_ticket_card(
+        _registration(ticket_code="CLUB146-PAID-ABC123"), _event()
+    )
+
+    assert artifact.ticket_code == "CLUB146-PAID-ABC123"
+    assert artifact.filename.endswith("CLUB146-PAID-ABC123.png")
+
+
+def test_invalid_future_website_ticket_code_fails_closed():
+    with pytest.raises(TicketCardError, match="Invalid website-issued"):
+        make_ticket_card(_registration(ticket_code="../../not-a-ticket"), _event())
+
+
+@pytest.mark.asyncio
+async def test_send_paid_ticket_card_uses_telegram_photo():
+    bot = AsyncMock()
+    dependencies = MagicMock(bot=bot)
+    with patch("src.ticket_cards.get_dependency_manager", return_value=dependencies):
+        sent = await send_paid_ticket_card(123456789, _registration(), _event())
+
+    assert sent is True
+    call = bot.send_photo.await_args
+    assert call is not None
+    assert call.kwargs["chat_id"] == 123456789
+    assert call.kwargs["parse_mode"] is None
+    assert isinstance(call.kwargs["photo"], BufferedInputFile)
+    assert "Покажите эту карточку на входе" in call.kwargs["caption"]
+
+
+@pytest.mark.asyncio
+async def test_send_paid_ticket_card_does_not_touch_telegram_when_unpaid():
+    with patch("src.ticket_cards.get_dependency_manager") as dependencies:
+        sent = await send_paid_ticket_card(
+            123456789, _registration(status="pending"), _event()
+        )
+
+    assert sent is False
+    dependencies.assert_not_called()
+
+
+def _status_message():
+    message = AsyncMock()
+    message.from_user = MagicMock(id=123456789, username="petr")
+    message.chat = MagicMock(id=123456789, type="private")
+    message.text = "/status"
+    return message
+
+
+def _status_app(registration):
+    app = MagicMock()
+    app.save_event_log = AsyncMock()
+    app.get_user_active_registrations = AsyncMock(return_value=[registration])
+    app.get_event_for_registration = AsyncMock(return_value=_event())
+    app.get_enabled_events = AsyncMock(return_value=[_event()])
+    app.is_event_passed = MagicMock(return_value=False)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_status_resends_confirmed_ticket_card():
+    from src.router import status_handler
+
+    registration = _registration()
+    app = _status_app(registration)
+    with (
+        patch("src.router.send_safe", new_callable=AsyncMock) as send_safe,
+        patch("src.router.send_paid_ticket_card", new_callable=AsyncMock) as send_card,
+    ):
+        await status_handler(_status_message(), AsyncMock(), app)
+
+    status_text = send_safe.await_args.args[1]
+    assert "Именной билет действителен для входа и доступен ниже" in status_text
+    send_card.assert_awaited_once_with(123456789, registration, _event())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [None, "not paid", "pending", "declined"])
+async def test_status_never_sends_unconfirmed_ticket_card(status):
+    from src.router import status_handler
+
+    registration = _registration(status=status)
+    app = _status_app(registration)
+    with (
+        patch("src.router.send_safe", new_callable=AsyncMock) as send_safe,
+        patch("src.router.send_paid_ticket_card", new_callable=AsyncMock) as send_card,
+    ):
+        await status_handler(_status_message(), AsyncMock(), app)
+
+    status_text = send_safe.await_args.args[1]
+    assert "Заявка сохранена; действующего билета пока нет" in status_text
+    assert "после подтверждения оплаты" in status_text
+    send_card.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_admin_receipt_confirmation_sends_newly_unlocked_ticket():
+    from src.routers.payment import confirm_payment_callback
+
+    registration = _registration(
+        payment_status="pending",
+        discounted_payment_amount=2500,
+        regular_payment_amount=3000,
+    )
+    updated_registration = _registration(
+        payment_status="confirmed",
+        payment_amount=2500,
+        payment_history=[{"amount": 2500, "timestamp": "2026-07-20T12:00:00"}],
+        discounted_payment_amount=2500,
+        regular_payment_amount=3000,
+    )
+
+    callback = AsyncMock()
+    callback.data = f"confirm_payment_123456789_{EVENT_ID}_2500"
+    callback.message = AsyncMock()
+    callback.message.chat = MagicMock(id=-100146)
+    callback.message.caption = None
+    callback.message.text = "Проверка пожертвования"
+    callback.message.edit_reply_markup = AsyncMock()
+    callback.message.edit_text = AsyncMock()
+    callback.answer = AsyncMock()
+
+    state = AsyncMock()
+    state.get_state.return_value = None
+
+    app = MagicMock()
+    app.update_payment_status = AsyncMock()
+    app.collection.find_one = AsyncMock(return_value=updated_registration)
+    app.get_event_for_registration = AsyncMock(return_value=_event())
+    app.export_registered_users_to_google_sheets = AsyncMock()
+
+    with (
+        patch("src.routers.payment.app", app),
+        patch(
+            "src.routers.payment._resolve_registration_from_callback",
+            new_callable=AsyncMock,
+            return_value=registration,
+        ),
+        patch(
+            "src.routers.payment._resolve_payment_amount",
+            new_callable=AsyncMock,
+            return_value=2500,
+        ),
+        patch("src.routers.payment.send_safe", new_callable=AsyncMock),
+        patch(
+            "src.routers.payment.send_paid_ticket_card", new_callable=AsyncMock
+        ) as send_card,
+    ):
+        await confirm_payment_callback(callback, state)
+
+    app.update_payment_status.assert_awaited_once_with(
+        123456789,
+        event_id=EVENT_ID,
+        status="confirmed",
+        payment_amount=2500,
+    )
+    send_card.assert_awaited_once_with(123456789, updated_registration, _event())

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,10 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P14D"
+
 [[package]]
 name = "aiofiles"
 version = "25.1.0"
@@ -2931,7 +2935,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3817,6 +3821,7 @@ dependencies = [
     { name = "motor" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -3867,6 +3872,7 @@ requires-dist = [
     { name = "motor" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "pandas", specifier = ">=2.2.1" },
+    { name = "pillow", specifier = ">=12.1.1,<13" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "python-dotenv" },
@@ -4125,8 +4131,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What changed

- issues a personalized PNG entry ticket only for registrations whose exact payment status is `confirmed`
- sends the ticket immediately after either receipt confirmation path and restores it through `/status`
- lists the registrant and up to three named guests on the transitional group card
- documents the future per-human website admission/ticket API without mixing event money into donation or endowment totals

## Why

For the August 1 event, a confirmed required attendance payment must unlock a recoverable personalized entry ticket. Unpaid, pending, declined, or missing-status registrations must fail closed.

## User impact

Paid attendees receive a clear Russian entry card with their name, event date, venue, payment confirmation, and a deterministic visual reference code. Until the signed website verification bridge is deployed, door staff must pair the card with the confirmed-registration list and the attendee name.

## Validation

- `577 passed`
- `ruff check --no-cache .` passes
- `uv lock --check` passes
- `git diff --check` passes
- representative Cyrillic card visually checked with a long name, venue/address, and three guests

## Rollout

Merge to `dev` and verify in `@register_146_meetup_test_bot` first. Do not promote to production until the TEST payment-confirmation and `/status` recovery flows are accepted.
