### PR TITLE
Late payment timeline, fewer pay messages, admin free/discount

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -503,6 +503,19 @@ class App:
         registrations = await cursor.to_list(length=1)
         return registrations[0] if registrations else None
 
+    async def get_profile_for_reuse(self, user_id: int) -> Optional[Dict]:
+        """Profile fields for re-registration: active reg first, else newest deleted.
+
+        Soft-deleted rows (e.g. «too expensive») keep full_name / year / letter so
+        the user does not retype the form.
+        """
+        active = await self.get_user_registration(user_id)
+        if active and active.get("full_name"):
+            return active
+        cursor = self.deleted_users.find({"user_id": user_id}).sort("_id", -1)
+        deleted = await cursor.to_list(length=1)
+        return deleted[0] if deleted else None
+
     async def delete_user_registration(
         self,
         user_id: int,

--- a/src/payment_reminders.py
+++ b/src/payment_reminders.py
@@ -1,0 +1,83 @@
+"""Send D-4 / D-2 payment reminders to unpaid registrants."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from loguru import logger
+
+from src.payment_timeline import reminder_kind_for_event, reminder_message
+
+
+async def iter_unpaid_for_reminders(app, event: dict) -> list[dict]:
+    event_id = str(event["_id"])
+    cursor = app.collection.find(
+        {
+            "event_id": event_id,
+            "payment_status": {"$nin": ["confirmed", "pending"]},
+        }
+    )
+    return await cursor.to_list(length=None)
+
+
+async def send_payment_reminders(
+    app,
+    bot,
+    *,
+    now: Optional[datetime] = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Scan upcoming events; send at most one D-4 and one D-2 per registration.
+
+    Marks ``payment_reminder_d4_sent`` / ``payment_reminder_d2_sent`` on the reg.
+    """
+    now = now or datetime.now()
+    stats = {"events": 0, "d4": 0, "d2": 0, "errors": 0, "skipped": 0}
+
+    events = await app.get_all_events()
+    for event in events:
+        status = event.get("status")
+        if status in ("archived", "passed"):
+            continue
+        if not event.get("enabled", True) and status != "upcoming":
+            # still allow registration_closed if people need to pay
+            if status not in ("upcoming", "registration_closed"):
+                continue
+
+        kind = reminder_kind_for_event(event, now)
+        if not kind:
+            continue
+
+        stats["events"] += 1
+        city = event.get("city", "городе")
+        text = reminder_message(kind, event, city)
+        flag = (
+            "payment_reminder_d4_sent" if kind == "d4" else "payment_reminder_d2_sent"
+        )
+
+        unpaid = await iter_unpaid_for_reminders(app, event)
+        for reg in unpaid:
+            if reg.get(flag):
+                stats["skipped"] += 1
+                continue
+            user_id = reg.get("user_id")
+            if not user_id:
+                stats["skipped"] += 1
+                continue
+            if dry_run:
+                stats[kind] += 1
+                continue
+            try:
+                await bot.send_message(int(user_id), text)
+                await app.collection.update_one(
+                    {"_id": reg["_id"]},
+                    {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
+                )
+                stats[kind] += 1
+            except Exception as e:
+                stats["errors"] += 1
+                logger.warning(
+                    f"payment reminder {kind} failed for user {user_id}: {e}"
+                )
+
+    return stats

--- a/src/payment_timeline.py
+++ b/src/payment_timeline.py
@@ -1,0 +1,159 @@
+"""Meetup payment timeline: food planning (D-4) and named badge (D-2).
+
+Deadlines are at 06:00 on the calendar day N days before the event date
+(buffer: “before six in the morning”). Timezone-naive datetimes are treated
+as local wall time of the stored event date.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from typing import Any, Optional
+
+
+FOOD_DAYS_BEFORE = 4
+BADGE_DAYS_BEFORE = 2
+DEADLINE_HOUR = 6  # 06:00
+
+
+def _as_date(value: Any) -> Optional[date]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+        except ValueError:
+            return None
+    return None
+
+
+def event_date(event: dict) -> Optional[date]:
+    return _as_date(event.get("date"))
+
+
+def deadline_at(event: dict, days_before: int, hour: int = DEADLINE_HOUR) -> Optional[datetime]:
+    """Instant after which the “late” rule applies (06:00 on that morning)."""
+    d = event_date(event)
+    if d is None:
+        return None
+    day = d - timedelta(days=days_before)
+    return datetime.combine(day, time(hour=hour, minute=0, second=0))
+
+
+def food_deadline(event: dict) -> Optional[datetime]:
+    return deadline_at(event, FOOD_DAYS_BEFORE)
+
+
+def badge_deadline(event: dict) -> Optional[datetime]:
+    return deadline_at(event, BADGE_DAYS_BEFORE)
+
+
+def format_deadline_ru(dt: Optional[datetime]) -> str:
+    if dt is None:
+        return "—"
+    return dt.strftime("%d.%m.%Y в %H:%M")
+
+
+@dataclass(frozen=True)
+class TimelineCopy:
+    food_deadline: Optional[datetime]
+    badge_deadline: Optional[datetime]
+    food_deadline_display: str
+    badge_deadline_display: str
+    after_food_deadline: bool
+    after_badge_deadline: bool
+
+
+def timeline_for(event: dict, now: Optional[datetime] = None) -> TimelineCopy:
+    now = now or datetime.now()
+    food = food_deadline(event)
+    badge = badge_deadline(event)
+    return TimelineCopy(
+        food_deadline=food,
+        badge_deadline=badge,
+        food_deadline_display=format_deadline_ru(food),
+        badge_deadline_display=format_deadline_ru(badge),
+        after_food_deadline=bool(food and now >= food),
+        after_badge_deadline=bool(badge and now >= badge),
+    )
+
+
+def pay_later_message(event: dict, now: Optional[datetime] = None) -> str:
+    """User-facing text after «Оплачу позже»."""
+    t = timeline_for(event, now)
+    return (
+        "Хорошо! Вы можете оплатить позже — команда /pay "
+        "(там же ссылка на сайт и реквизиты).\n\n"
+        "⏱ Сроки (ориентир — 06:00):\n"
+        f"• до <b>{t.food_deadline_display}</b> — успеваете в общий заказ еды;\n"
+        f"• после этой даты — пожалуйста, <b>принесите немного еды с собой</b>: "
+        "мы заказываем заранее, и при большом числе поздних оплат на месте "
+        "может не хватить / придётся докупать.\n"
+        f"• до <b>{t.badge_deadline_display}</b> — успеваем подготовить "
+        "<b>именной бейдж</b>;\n"
+        "• позже — бейдж уже не печатаем (вас всё равно ждут).\n\n"
+        "После оплаты пришлите скриншот в этот чат (или нажмите «Оплатил» в /pay)."
+    )
+
+
+def reminder_kind_for_event(
+    event: dict, now: Optional[datetime] = None
+) -> Optional[str]:
+    """Return ``d4`` or ``d2`` if *now* falls on that reminder calendar day.
+
+    Reminder day = calendar day of the corresponding 06:00 deadline
+    (D-4 food planning day, D-2 badge day).
+    """
+    now = now or datetime.now()
+    food = food_deadline(event)
+    badge = badge_deadline(event)
+    today = now.date()
+    if food and today == food.date():
+        return "d4"
+    if badge and today == badge.date():
+        return "d2"
+    return None
+
+
+def reminder_message(kind: str, event: dict, city: str) -> str:
+    t = timeline_for(event)
+    if kind == "d4":
+        return (
+            f"Напоминание о встрече в {city}: до мероприятия 4 дня.\n\n"
+            f"Если ещё не оплатили взнос — сейчас удобное время (/pay).\n"
+            f"После <b>{t.food_deadline_display}</b> еду планируем с запасом; "
+            "при поздней оплате лучше принести что-то к столу с собой.\n"
+            f"Именной бейдж — если оплатите до <b>{t.badge_deadline_display}</b>."
+        )
+    if kind == "d2":
+        return (
+            f"Напоминание о встрече в {city}: осталось 2 дня.\n\n"
+            f"<b>Последний срок для именного бейджа</b> — "
+            f"<b>{t.badge_deadline_display}</b>.\n"
+            "Оплатить: /pay. После оплаты пришлите скриншот в чат."
+        )
+    raise ValueError(f"unknown reminder kind: {kind}")
+
+
+VOLUNTEER_OPTIONS_TEXT = (
+    "Если хотите помочь вместо взноса или в дополнение — напишите "
+    "организатору <b>@mariikors</b>. Мария решает индивидуально "
+    "(скидка / бесплатный вход / волонтёрство).\n\n"
+    "Примеры задач:\n"
+    "• проверка бейджей на входе\n"
+    "• помощь с готовкой / уборкой / орг. делами\n"
+    "• фото, видео, stories\n"
+    "• активности, музыка, программа"
+)
+
+
+def too_expensive_cancel_message() -> str:
+    return (
+        "Понимаем. Регистрацию отменили.\n\n"
+        "Если передумаете — /start (данные подставим, если найдём прошлую анкету).\n\n"
+        f"{VOLUNTEER_OPTIONS_TEXT}"
+    )

--- a/src/router.py
+++ b/src/router.py
@@ -1998,7 +1998,7 @@ async def start_handler(message: Message, state: FSMContext, app: App):
                 state=state,
             )
             if want_register:
-                existing_registration = await app.get_user_registration(
+                existing_registration = await app.get_profile_for_reuse(
                     message.from_user.id
                 )
                 await register_user(
@@ -2013,7 +2013,8 @@ async def start_handler(message: Message, state: FSMContext, app: App):
     if active_registrations:
         await handle_registered_user(message, state, active_registrations[0], app)
     else:
-        existing_registration = await app.get_user_registration(message.from_user.id)
+        # Soft-deleted (e.g. «too expensive») still prefill name/year on re-register.
+        existing_registration = await app.get_profile_for_reuse(message.from_user.id)
         if len(upcoming_events) == 1:
             await _show_single_event_welcome(
                 message, state, app, upcoming_events[0], existing_registration

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -62,6 +62,8 @@ async def admin_handler(message: Message, state: FSMContext, app: App):
             choices={
                 "manage_events": "Управление встречами",
                 "register_payment": "Зарегистрировать оплату (за другого участника)",
+                "discretionary": "Скидка / бесплатный вход (решение Марии)",
+                "payment_reminders": "Напоминания об оплате (D-4 / D-2)",
                 "export": "Экспортировать данные",
             },
             state=state,
@@ -104,6 +106,10 @@ async def admin_handler(message: Message, state: FSMContext, app: App):
         await manage_events_handler(message, state, app=app)
     elif response == "register_payment":
         await admin_register_payment(message, state, app)
+    elif response == "discretionary":
+        await admin_discretionary_payment(message, state, app)
+    elif response == "payment_reminders":
+        await admin_run_payment_reminders(message, app)
     elif response == "export":
         await export_handler(message, state, app=app)
     elif response == "notify_users":
@@ -288,43 +294,169 @@ async def admin_register_payment(message: Message, state: FSMContext, app: App):
     if amount is None:
         return
 
-    if target_user_id:
-        await app.update_payment_status(
-            user_id=int(target_user_id),
-            event_id=selected,
-            status="confirmed",
-            payment_amount=amount,
-            admin_id=message.from_user.id if message.from_user else None,
-            admin_username=message.from_user.username if message.from_user else None,
-        )
-
-        # Notify the user
-        try:
-            from botspot.core.dependency_manager import get_dependency_manager
-
-            bot = get_dependency_manager().bot
-            await bot.send_message(
-                int(target_user_id),
-                f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!\n"
-                "Именной билет отправляем следующим сообщением. "
-                "Если он не появится, откройте /status.",
-            )
-        except Exception as e:
-            logger.warning(f"Could not notify user {target_user_id}: {e}")
-
-        await _send_admin_confirmed_ticket(app, int(target_user_id), selected)
-    else:
-        # No user_id — update by registration _id
-        await app.collection.update_one(
-            {"_id": reg["_id"]},
-            {"$set": {"payment_status": "confirmed", "payment_amount": amount}},
-        )
-
+    await _apply_admin_confirmed_payment(
+        app,
+        message,
+        reg=reg,
+        target_user_id=target_user_id,
+        target_name=target_name,
+        event_id=selected,
+        amount=amount,
+        admin_comment=None,
+        user_note=(
+            f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!\n"
+            "Именной билет отправляем следующим сообщением. "
+            "Если он не появится, откройте /status."
+        ),
+    )
     await send_safe(
         chat_id,
         f"Оплата {amount}₽ подтверждена для {target_name}.",
     )
     await app.export_registered_users_to_google_sheets()
+
+
+async def _apply_admin_confirmed_payment(
+    app: App,
+    message: Message,
+    *,
+    reg: dict,
+    target_user_id,
+    target_name: str,
+    event_id: str,
+    amount: int,
+    admin_comment: Optional[str],
+    user_note: str,
+) -> None:
+    if target_user_id:
+        kwargs = dict(
+            user_id=int(target_user_id),
+            event_id=event_id,
+            status="confirmed",
+            payment_amount=amount,
+            admin_id=message.from_user.id if message.from_user else None,
+            admin_username=message.from_user.username if message.from_user else None,
+        )
+        if admin_comment:
+            kwargs["admin_comment"] = admin_comment
+        await app.update_payment_status(**kwargs)
+        try:
+            from botspot.core.dependency_manager import get_dependency_manager
+
+            bot = get_dependency_manager().bot
+            await bot.send_message(int(target_user_id), user_note)
+        except Exception as e:
+            logger.warning(f"Could not notify user {target_user_id}: {e}")
+        await _send_admin_confirmed_ticket(app, int(target_user_id), event_id)
+    else:
+        from datetime import datetime
+
+        update = {
+            "payment_status": "confirmed",
+            "payment_amount": amount,
+            "payment_verified_at": datetime.now().isoformat(),
+        }
+        if admin_comment:
+            update["admin_comment"] = admin_comment
+        await app.collection.update_one({"_id": reg["_id"]}, {"$set": update})
+
+
+async def admin_discretionary_payment(
+    message: Message, state: FSMContext, app: App
+) -> None:
+    """Maria/admin: free entry or custom discounted amount for one registrant."""
+    chat_id = message.chat.id
+    selected = await _select_event_for_payment(chat_id, state, app)
+    if not selected:
+        return
+
+    user_result = await _select_unpaid_user(chat_id, state, app, selected)
+    if not user_result:
+        return
+    reg, target_user_id, target_name = user_result
+
+    mode = await ask_user_choice(
+        chat_id,
+        f"Участник: {target_name}\n"
+        "Решение по взносу (скидка / бесплатно — на усмотрение Марии):",
+        choices={
+            "free": "Бесплатный вход (0 ₽, confirmed)",
+            "discount": "Своя сумма (скидка) → confirmed",
+            "cancel": "Отмена",
+        },
+        state=state,
+        timeout=None,
+    )
+    if mode in (None, "cancel"):
+        await send_safe(chat_id, "Отменено.")
+        return
+
+    if mode == "free":
+        amount = 0
+        comment = "discretionary_free"
+        user_note = (
+            "Для вас вход на встречу подтверждён без оплаты "
+            "(решение организаторов). Спасибо, что с нами!\n"
+            "Именной билет — следующим сообщением (или /status)."
+        )
+    else:
+        amount = await _confirm_payment_amount(
+            chat_id, state, f"{target_name} (скидочная сумма)"
+        )
+        if amount is None:
+            return
+        comment = f"discretionary_discount:{amount}"
+        user_note = (
+            f"Ваш взнос зафиксирован как {amount}₽ "
+            f"(индивидуальное решение организаторов). Спасибо!\n"
+            "Именной билет — следующим сообщением (или /status)."
+        )
+
+    await _apply_admin_confirmed_payment(
+        app,
+        message,
+        reg=reg,
+        target_user_id=target_user_id,
+        target_name=target_name,
+        event_id=selected,
+        amount=amount,
+        admin_comment=comment,
+        user_note=user_note,
+    )
+    await send_safe(
+        chat_id,
+        f"Готово: {target_name} — "
+        f"{'бесплатно' if amount == 0 else f'{amount}₽ (скидка)'}, статус confirmed.",
+    )
+    await app.export_registered_users_to_google_sheets()
+
+
+async def admin_run_payment_reminders(message: Message, app: App) -> None:
+    """Run D-4 / D-2 payment reminder scan (idempotent flags on registrations)."""
+    from botspot.core.dependency_manager import get_dependency_manager
+    from src.payment_reminders import send_payment_reminders
+
+    chat_id = message.chat.id
+    await send_safe(
+        chat_id,
+        "Запускаю проверку напоминаний (D-4 еда / D-2 бейдж)…",
+    )
+    try:
+        bot = get_dependency_manager().bot
+        stats = await send_payment_reminders(app, bot, dry_run=False)
+    except Exception as e:
+        logger.exception("payment reminders failed")
+        await send_safe(chat_id, f"Ошибка: {e}")
+        return
+    await send_safe(
+        chat_id,
+        "Напоминания:\n"
+        f"• событий в окне D-4/D-2: {stats['events']}\n"
+        f"• отправлено D-4: {stats['d4']}\n"
+        f"• отправлено D-2: {stats['d2']}\n"
+        f"• пропущено (уже слали / нет user_id): {stats['skipped']}\n"
+        f"• ошибок: {stats['errors']}",
+    )
 
 
 @commands_menu.add_command(

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -216,21 +216,23 @@ async def _send_payment_info_messages(
     full_name: str = "",
     graduation_year: int | str | None = None,
 ):
+    """Send payment info in two user-visible messages (price+guests, then how to pay)."""
     from botspot.core.dependency_manager import get_dependency_manager
     from src.pay_url import build_pay_url
 
     deps = get_dependency_manager()
     await deps.bot.send_chat_action(chat_id=message.chat.id, action="typing")
-    await asyncio.sleep(3)
+    await asyncio.sleep(1)
 
     payment_formula = _build_payment_formula(event)
+    chunks: list[str] = []
 
     if graduate_type != GraduateType.NON_GRADUATE.value:
-        payment_msg_part1 = templates.render(
-            event, "payment_intro", {"city": city, "formula": payment_formula}
+        chunks.append(
+            templates.render(
+                event, "payment_intro", {"city": city, "formula": payment_formula}
+            ).strip()
         )
-        await send_safe(message.chat.id, payment_msg_part1)
-        await asyncio.sleep(5)
 
     price_label = (
         "Минимальный взнос для вас"
@@ -244,33 +246,35 @@ async def _send_payment_info_messages(
     if is_early:
         assert early_bird_deadline is not None
         deadline_display = early_bird_deadline.strftime("%d.%m")
-        payment_msg_part2 = templates.render(
-            event,
-            "payment_price_early",
-            {
-                "price_label": price_label,
-                "regular_amount": regular_amount,
-                "deadline": deadline_display,
-                "discount": early_bird_discount_amount,
-                "discounted_amount": discounted_amount,
-                "season": season,
-            },
+        chunks.append(
+            templates.render(
+                event,
+                "payment_price_early",
+                {
+                    "price_label": price_label,
+                    "regular_amount": regular_amount,
+                    "deadline": deadline_display,
+                    "discount": early_bird_discount_amount,
+                    "discounted_amount": discounted_amount,
+                    "season": season,
+                },
+            ).strip()
         )
     else:
-        payment_msg_part2 = templates.render(
-            event,
-            "payment_price_regular",
-            {
-                "price_label": price_label,
-                "regular_amount": regular_amount,
-                "season": season,
-            },
+        chunks.append(
+            templates.render(
+                event,
+                "payment_price_regular",
+                {
+                    "price_label": price_label,
+                    "regular_amount": regular_amount,
+                    "season": season,
+                },
+            ).strip()
         )
 
-    await send_safe(message.chat.id, payment_msg_part2)
-
     if guests:
-        guest_msg = f"\n👥 Гости ({len(guests)}):\n"
+        guest_msg = f"👥 Гости ({len(guests)}):\n"
         for i, g in enumerate(guests, 1):
             guest_name = escape(str(g["name"]), quote=True)
             guest_msg += f"  {i}. {guest_name} — {g['price']} руб.\n"
@@ -283,10 +287,10 @@ async def _send_payment_info_messages(
             guest_msg += (
                 f"\n💰 <b>Итого с гостями: {total_regular_with_guests} руб.</b>"
             )
-        await send_safe(message.chat.id, guest_msg)
-        await asyncio.sleep(2)
+        chunks.append(guest_msg.strip())
 
-    await asyncio.sleep(3)
+    await send_safe(message.chat.id, "\n\n".join(chunks))
+    await asyncio.sleep(1)
 
     # Same total the user is told to pay (early-bird + guests when applicable).
     pay_amount = total_discounted_with_guests if is_early else total_regular_with_guests
@@ -306,7 +310,7 @@ async def _send_payment_info_messages(
         },
     )
     await send_safe(message.chat.id, payment_msg_part3)
-    await asyncio.sleep(3)
+    await asyncio.sleep(1)
 
 
 async def _handle_pay_later(
@@ -319,10 +323,16 @@ async def _handle_pay_later(
     regular_amount: int,
     formula_amount: int,
     graduate_type: str,
+    event: dict | None = None,
 ):
+    from src.payment_timeline import pay_later_message
+
+    if event is None:
+        event = await app.get_event_by_id(event_id) or {}
+
     await send_safe(
         message.chat.id,
-        "Хорошо! Вы можете оплатить позже, используя команду /pay",
+        pay_later_message(event),
         reply_markup=ReplyKeyboardRemove(),
     )
     await app.log_registration_step(
@@ -346,7 +356,25 @@ async def _handle_pay_later(
         discounted_amount=discounted_amount,
         regular_amount=regular_amount,
         formula_amount=formula_amount,
+        payment_status="not paid",
     )
+    # Mark for reminder job (not yet reminded).
+    try:
+        coll = app.collection
+        update = coll.update_one(
+            {"user_id": user_id, "event_id": event_id},
+            {
+                "$set": {
+                    "pay_later_selected": True,
+                    "payment_reminder_d4_sent": False,
+                    "payment_reminder_d2_sent": False,
+                }
+            },
+        )
+        if hasattr(update, "__await__"):
+            await update
+    except Exception as e:
+        logger.warning(f"Could not set pay_later flags for {user_id}: {e}")
 
 
 async def _handle_too_expensive(
@@ -358,7 +386,10 @@ async def _handle_too_expensive(
     discounted_amount: int,
     regular_amount: int,
     graduate_type: str,
+    state: FSMContext | None = None,
 ):
+    from src.payment_timeline import too_expensive_cancel_message
+
     await app.log_registration_step(
         user_id=user_id,
         username=username,
@@ -384,13 +415,55 @@ async def _handle_too_expensive(
 
     if registration:
         full_name = registration.get("full_name", "Unknown")
-        await app.delete_user_registration(user_id, event_id)
+        # Soft-delete keeps the row in deleted_users so /start can reuse profile.
+        await app.delete_user_registration(
+            user_id, event_id, username=username, full_name=full_name
+        )
         await app.log_registration_canceled(user_id, username, full_name, city)
         await send_safe(
             message.chat.id,
-            "Понимаем! Ваша регистрация отменена. Если передумаете, вы всегда можете зарегистрироваться снова с помощью команды /start",
+            too_expensive_cancel_message(),
             reply_markup=ReplyKeyboardRemove(),
         )
+        if state is not None:
+            interest = await ask_user_choice(
+                message.chat.id,
+                "Хотите, чтобы мы отметили интерес к волонтёрству "
+                "(Мария @mariikors свяжется / учтёт)?",
+                choices={
+                    "volunteer_yes": "Да, интересно волонтёрство",
+                    "volunteer_no": "Нет, спасибо",
+                },
+                state=state,
+                timeout=300,
+            )
+            if interest == "volunteer_yes":
+                await app.save_event_log(
+                    "payment_action",
+                    {
+                        "action": "volunteer_interest_after_too_expensive",
+                        "city": city,
+                        "full_name": full_name,
+                        "amount": discounted_amount,
+                    },
+                    user_id,
+                    username,
+                )
+                try:
+                    await app.log_to_chat(
+                        f"🙋 Волонтёрский интерес (после «дорого»)\n"
+                        f"{full_name} (@{username or '—'})\n"
+                        f"user_id={user_id} · {city} · взнос был {discounted_amount}₽\n"
+                        f"→ @mariikors",
+                        "events",
+                    )
+                except Exception as e:
+                    logger.warning(f"Could not log volunteer interest to events chat: {e}")
+                await send_safe(
+                    message.chat.id,
+                    "Отметили интерес. Напишите @mariikors — она решает "
+                    "скидку / бесплатный вход / задачи.",
+                )
     else:
         await send_safe(
             message.chat.id,
@@ -733,9 +806,12 @@ async def _handle_screenshot_upload(
     )
 
     if not (has_photo or has_pdf):
+        from src.payment_timeline import pay_later_message
+
+        event = await app.get_event_by_id(event_id) or {}
         await send_safe(
             message.chat.id,
-            "Хорошо! Вы можете оплатить позже, используя команду /pay",
+            pay_later_message(event),
             reply_markup=ReplyKeyboardRemove(),
         )
         await app.save_payment_info(
@@ -743,6 +819,7 @@ async def _handle_screenshot_upload(
             event_id=event_id,
             discounted_amount=discounted_amount,
             regular_amount=regular_amount,
+            payment_status="not paid",
         )
         return False
 
@@ -953,6 +1030,7 @@ async def process_payment(
                 regular_amount,
                 formula_amount,
                 graduate_type,
+                event=event,
             )
             return False
         if response == "too_expensive":
@@ -965,6 +1043,7 @@ async def process_payment(
                 discounted_amount,
                 regular_amount,
                 graduate_type,
+                state=state,
             )
             return False
 

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -602,11 +602,13 @@ async def test_send_payment_info_escapes_guest_name_for_telegram_html(
             total_discounted_with_guests=2300,
         )
 
-    guest_message = mock_send_safe.call_args_list[2].args[1]
+    # Price + guests are merged into the first message; how-to-pay is second.
+    first_message = mock_send_safe.call_args_list[0].args[1]
     assert (
-        "&lt;Тег&gt; &amp; &quot;двойная&quot; &#x27;одинарная&#x27;" in guest_message
+        "&lt;Тег&gt; &amp; &quot;двойная&quot; &#x27;одинарная&#x27;" in first_message
     )
-    assert "<Тег> & \"двойная\" 'одинарная'" not in guest_message
+    assert "<Тег> & \"двойная\" 'одинарная'" not in first_message
+    assert len(mock_send_safe.call_args_list) == 2
 
 
 def test_build_user_info_text_teacher():

--- a/tests/test_payment_reminders.py
+++ b/tests/test_payment_reminders.py
@@ -1,0 +1,76 @@
+"""Tests for payment reminder selection (no real bot sends)."""
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.payment_reminders import send_payment_reminders
+
+
+@pytest.mark.asyncio
+async def test_send_payment_reminders_d4_marks_flag():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    reg = {
+        "_id": "reg1",
+        "user_id": 42,
+        "event_id": "evt1",
+        "payment_status": "not paid",
+        "payment_reminder_d4_sent": False,
+    }
+
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    app.collection.find = MagicMock(
+        return_value=MagicMock(to_list=AsyncMock(return_value=[reg]))
+    )
+    app.collection.update_one = AsyncMock()
+
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    stats = await send_payment_reminders(
+        app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
+    )
+    assert stats["d4"] == 1
+    assert stats["d2"] == 0
+    bot.send_message.assert_awaited_once()
+    app.collection.update_one.assert_awaited()
+    assert "payment_reminder_d4_sent" in str(app.collection.update_one.await_args)
+
+
+@pytest.mark.asyncio
+async def test_send_payment_reminders_skips_already_sent():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    reg = {
+        "_id": "reg1",
+        "user_id": 42,
+        "event_id": "evt1",
+        "payment_status": None,
+        "payment_reminder_d4_sent": True,
+    }
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    app.collection.find = MagicMock(
+        return_value=MagicMock(to_list=AsyncMock(return_value=[reg]))
+    )
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    stats = await send_payment_reminders(
+        app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
+    )
+    assert stats["skipped"] == 1
+    assert stats["d4"] == 0
+    bot.send_message.assert_not_awaited()

--- a/tests/test_payment_timeline.py
+++ b/tests/test_payment_timeline.py
@@ -1,0 +1,69 @@
+"""Unit tests for payment timeline (D-4 food / D-2 badge, 06:00)."""
+from datetime import date, datetime
+
+from src.payment_timeline import (
+    BADGE_DAYS_BEFORE,
+    FOOD_DAYS_BEFORE,
+    badge_deadline,
+    food_deadline,
+    pay_later_message,
+    reminder_kind_for_event,
+    reminder_message,
+    timeline_for,
+    too_expensive_cancel_message,
+)
+
+
+def _event(day: date | datetime) -> dict:
+    return {"date": day, "city": "Пермь"}
+
+
+def test_deadlines_are_four_and_two_days_before_at_six_am():
+    event = _event(date(2026, 8, 1))
+    food = food_deadline(event)
+    badge = badge_deadline(event)
+    assert food == datetime(2026, 7, 28, 6, 0, 0)
+    assert badge == datetime(2026, 7, 30, 6, 0, 0)
+    assert FOOD_DAYS_BEFORE == 4
+    assert BADGE_DAYS_BEFORE == 2
+
+
+def test_timeline_flags_after_deadlines():
+    event = _event(date(2026, 8, 1))
+    before = timeline_for(event, now=datetime(2026, 7, 27, 12, 0))
+    assert not before.after_food_deadline
+    assert not before.after_badge_deadline
+    mid = timeline_for(event, now=datetime(2026, 7, 29, 12, 0))
+    assert mid.after_food_deadline
+    assert not mid.after_badge_deadline
+    late = timeline_for(event, now=datetime(2026, 7, 31, 12, 0))
+    assert late.after_food_deadline
+    assert late.after_badge_deadline
+
+
+def test_reminder_kind_on_deadline_calendar_days():
+    event = _event(date(2026, 8, 1))
+    assert reminder_kind_for_event(event, now=datetime(2026, 7, 28, 10, 0)) == "d4"
+    assert reminder_kind_for_event(event, now=datetime(2026, 7, 30, 10, 0)) == "d2"
+    assert reminder_kind_for_event(event, now=datetime(2026, 7, 29, 10, 0)) is None
+
+
+def test_pay_later_message_contains_dates_and_rules():
+    event = _event(date(2026, 8, 1))
+    text = pay_later_message(event)
+    assert "28.07.2026" in text
+    assert "30.07.2026" in text
+    assert "еды" in text.lower() or "еду" in text.lower()
+    assert "бейдж" in text.lower()
+    assert "/pay" in text
+
+
+def test_reminder_and_too_expensive_copy():
+    event = _event(date(2026, 8, 1))
+    d4 = reminder_message("d4", event, "Пермь")
+    d2 = reminder_message("d2", event, "Пермь")
+    assert "4 дня" in d4 or "4 дн" in d4
+    assert "бейдж" in d2.lower()
+    cancel = too_expensive_cancel_message()
+    assert "@mariikors" in cancel
+    assert "волонт" in cancel.lower() or "Волонт" in cancel


### PR DESCRIPTION
## Summary
- D-4 food / D-2 badge rules at 06:00 with pay-later copy and optional admin-triggered reminders
- Payment info reduced to two user messages (price+guests, then how to pay)
- Too-expensive cancels with volunteer opt-in and soft-delete profile reuse on re-register
- Admin: discretionary free/discount confirmation; D-4/D-2 reminder scan

## Test plan
- [x] `pytest tests/test_payment_timeline.py tests/test_payment_reminders.py tests/test_payment.py tests/test_admin.py` (89 passed)
- [ ] Smoke on TEST bot: /pay → Оплачу позже (timeline text)
- [ ] Smoke: too expensive → cancel + volunteer opt-in
- [ ] Admin → Скидка/бесплатный вход; Напоминания об оплате

Handoff: `handoffs/32-146-late-payment-comms-admin.md`