### PR TITLE
Auto payment reminders: schedule, admin preview, pause/send-now

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -46,8 +46,16 @@ def main(debug=False) -> None:
     bm = BotManager(bot=bot)
     bm.settings.ask_user.enabled = False
 
-    # Run database fix on startup
-    dp.startup.register(app.startup)
+    async def on_startup() -> None:
+        await app.startup()
+        try:
+            from src.reminder_scheduler import start_reminder_scheduler
+
+            start_reminder_scheduler(app, bot)
+        except Exception:
+            logger.exception("Failed to start payment reminder scheduler")
+
+    dp.startup.register(on_startup)
 
     # Setup dispatcher with our components
     bm.setup_dispatcher(dp)

--- a/src/export.py
+++ b/src/export.py
@@ -228,88 +228,69 @@ class SheetExporter:
         all_events = await self.app.get_all_events()
         return _build_events_map(all_events)
 
-    async def export_registered_users(
-        self, silent=False, event_id: Optional[str] = None
-    ):
-        """Export registered users to Google Sheets."""
-        query = {"event_id": event_id} if event_id else {}
-        cursor = self.app.collection.find(query)
-        users = await cursor.to_list(length=None)
+    def _ensure_worksheet(self, spreadsheet, titles: list, title: str):
+        """Return worksheet, creating it if missing; mutates *titles*."""
+        if title not in titles:
+            spreadsheet.add_worksheet(title=title, rows=1000, cols=20)
+            titles.append(title)
+        return spreadsheet.worksheet(title)
 
-        if not users:
-            logger.info("Нет пользователей для экспорта")
-            if not silent:
-                return "Нет пользователей для экспорта"
-            return None
-
-        events_map = await self._prefetch_events_map()
-
-        # Connect to Google Sheets
-        client = self._get_client()
-        spreadsheet = client.open_by_key(self.spreadsheet_id)
-        worksheet_titles = [ws.title for ws in spreadsheet.worksheets()]
-
-        # Main sheet
-        if "Все встречи" not in worksheet_titles:
-            spreadsheet.add_worksheet(title="Все встречи", rows=1000, cols=20)
-        main_sheet = spreadsheet.worksheet("Все встречи")
+    def _prepare_registered_export_sheets(self, spreadsheet, events_map: Dict):
+        """Create/clear main, per-event, and graduate-type worksheets."""
+        titles = [ws.title for ws in spreadsheet.worksheets()]
+        main_sheet = self._ensure_worksheet(spreadsheet, titles, "Все встречи")
         main_sheet.clear()
 
-        # Dynamic event-specific sheets (replace hardcoded cities)
         event_sheets = {}
         for eid, ev in events_map.items():
-            tab_name = ev.get("name", ev.get("city", eid))[
-                :100
-            ]  # Sheets tab name limit
-            if tab_name not in worksheet_titles:
-                spreadsheet.add_worksheet(title=tab_name, rows=1000, cols=20)
-                worksheet_titles.append(tab_name)
-            event_sheets[eid] = spreadsheet.worksheet(tab_name)
-            event_sheets[eid].clear()
+            tab_name = ev.get("name", ev.get("city", eid))[:100]
+            sheet = self._ensure_worksheet(spreadsheet, titles, tab_name)
+            sheet.clear()
+            event_sheets[eid] = sheet
 
-        # Graduate type sheets
         type_sheets = {}
-        for graduate_type in ["Выпускники", "Учителя", "Друзья", "Организаторы"]:
-            if graduate_type not in worksheet_titles:
-                spreadsheet.add_worksheet(title=graduate_type, rows=1000, cols=20)
-            type_sheets[graduate_type] = spreadsheet.worksheet(graduate_type)
-            type_sheets[graduate_type].clear()
+        for graduate_type in ("Выпускники", "Учителя", "Друзья", "Организаторы"):
+            sheet = self._ensure_worksheet(spreadsheet, titles, graduate_type)
+            sheet.clear()
+            type_sheets[graduate_type] = sheet
 
-        # Update all sheets with headers
         main_sheet.update([REGISTERED_HEADERS])
         for sheet in event_sheets.values():
             sheet.update([REGISTERED_HEADERS])
         for sheet in type_sheets.values():
             sheet.update([REGISTERED_HEADERS])
+        return main_sheet, event_sheets, type_sheets
 
-        # Build rows
+    @staticmethod
+    def _type_sheet_key(graduate_type: str) -> Optional[str]:
+        display = GRADUATE_TYPE_MAP.get(graduate_type, "Выпускник")
+        return {
+            "Выпускник": "Выпускники",
+            "Учитель": "Учителя",
+            "Друг": "Друзья",
+            "Организатор": "Организаторы",
+        }.get(display)
+
+    def _bucket_registered_rows(self, users, events_map, event_sheets, type_sheets):
         main_rows = []
         event_rows = {eid: [] for eid in event_sheets}
         type_rows = {gt: [] for gt in type_sheets}
-
         for user in users:
             event = events_map.get(user.get("event_id", ""))
             row = _build_registered_row(user, event)
             main_rows.append(row)
-
-            # Route to event sheet
             uid_event = user.get("event_id", "")
             if uid_event in event_rows:
                 event_rows[uid_event].append(row)
+            key = self._type_sheet_key(user.get("graduate_type", "GRADUATE"))
+            if key and key in type_rows:
+                type_rows[key].append(row)
+        return main_rows, event_rows, type_rows
 
-            # Route to type sheet
-            graduate_type = user.get("graduate_type", "GRADUATE")
-            graduate_type_display = GRADUATE_TYPE_MAP.get(graduate_type, "Выпускник")
-            if graduate_type_display == "Выпускник":
-                type_rows["Выпускники"].append(row)
-            elif graduate_type_display == "Учитель":
-                type_rows["Учителя"].append(row)
-            elif graduate_type_display == "Друг":
-                type_rows["Друзья"].append(row)
-            elif graduate_type_display == "Организатор":
-                type_rows["Организаторы"].append(row)
-
-        # Write data
+    @staticmethod
+    def _write_row_buckets(
+        main_sheet, main_rows, event_sheets, event_rows, type_sheets, type_rows
+    ):
         if main_rows:
             main_sheet.update(main_rows, "A2")
         for eid, rows in event_rows.items():
@@ -319,15 +300,35 @@ class SheetExporter:
             if rows:
                 type_sheets[gt].update(rows, "A2")
 
+    async def export_registered_users(
+        self, silent=False, event_id: Optional[str] = None
+    ):
+        """Export registered users to Google Sheets."""
+        query = {"event_id": event_id} if event_id else {}
+        users = await self.app.collection.find(query).to_list(length=None)
+
+        if not users:
+            logger.info("Нет пользователей для экспорта")
+            return None if silent else "Нет пользователей для экспорта"
+
+        events_map = await self._prefetch_events_map()
+        spreadsheet = self._get_client().open_by_key(self.spreadsheet_id)
+        main_sheet, event_sheets, type_sheets = self._prepare_registered_export_sheets(
+            spreadsheet, events_map
+        )
+        main_rows, event_rows, type_rows = self._bucket_registered_rows(
+            users, events_map, event_sheets, type_sheets
+        )
+        self._write_row_buckets(
+            main_sheet, main_rows, event_sheets, event_rows, type_sheets, type_rows
+        )
+
         message = (
             f"Успешно экспортировано {len(main_rows)} пользователей в Google Таблицы\n"
+            f"Доступно по ссылке: {main_sheet.url}"
         )
-        message += "Доступно по ссылке: " + main_sheet.url
         logger.success(message)
-
-        if not silent:
-            return message
-        return None
+        return None if silent else message
 
     async def export_to_csv(self, event_id: Optional[str] = None):
         """Export registered users to a CSV file."""

--- a/src/payment_reminders.py
+++ b/src/payment_reminders.py
@@ -1,16 +1,121 @@
-"""Send D-4 / D-2 payment reminders to unpaid registrants."""
+"""Payment reminders: auto schedule, admin preview (D-1), pause / send now.
+
+Control state lives in Mongo collection ``payment_reminder_controls``
+(one doc per event_id + kind). Per-user send flags stay on registrations.
+"""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Optional
 
 from loguru import logger
 
-from src.payment_timeline import reminder_kind_for_event, reminder_message
+from src.payment_timeline import (
+    admin_preview_kinds_for_event,
+    kind_label_ru,
+    reminder_kind_for_event,
+    reminder_message,
+)
+
+CONTROL_COLLECTION = "payment_reminder_controls"
+KIND_FLAG = {
+    "d4": "payment_reminder_d4_sent",
+    "d2": "payment_reminder_d2_sent",
+}
+
+
+def _event_id(event: dict) -> str:
+    return str(event["_id"])
+
+
+def _control_id(event_id: str, kind: str) -> str:
+    return f"{event_id}:{kind}"
+
+
+def _get_database():
+    from botspot import get_database
+
+    return get_database()
+
+
+async def controls_collection(app):
+    if getattr(app, "_reminder_controls", None) is None:
+        app._reminder_controls = _get_database().get_collection(CONTROL_COLLECTION)
+    return app._reminder_controls
+
+
+async def get_control(app, event_id: str, kind: str) -> dict:
+    col = await controls_collection(app)
+    doc = await col.find_one({"_id": _control_id(event_id, kind)})
+    if doc:
+        return doc
+    return {
+        "_id": _control_id(event_id, kind),
+        "event_id": event_id,
+        "kind": kind,
+        "paused": False,
+        "admin_preview_sent": False,
+        "admin_preview_sent_at": None,
+        "auto_send_completed": False,
+        "auto_send_completed_at": None,
+    }
+
+
+async def set_paused(app, event_id: str, kind: str, paused: bool) -> dict:
+    col = await controls_collection(app)
+    now = datetime.now().isoformat()
+    await col.update_one(
+        {"_id": _control_id(event_id, kind)},
+        {
+            "$set": {
+                "event_id": event_id,
+                "kind": kind,
+                "paused": paused,
+                "paused_updated_at": now,
+            },
+            "$setOnInsert": {"admin_preview_sent": False, "auto_send_completed": False},
+        },
+        upsert=True,
+    )
+    return await get_control(app, event_id, kind)
+
+
+async def mark_admin_preview_sent(app, event_id: str, kind: str) -> None:
+    col = await controls_collection(app)
+    await col.update_one(
+        {"_id": _control_id(event_id, kind)},
+        {
+            "$set": {
+                "event_id": event_id,
+                "kind": kind,
+                "admin_preview_sent": True,
+                "admin_preview_sent_at": datetime.now().isoformat(),
+            },
+            "$setOnInsert": {"paused": False, "auto_send_completed": False},
+        },
+        upsert=True,
+    )
+
+
+async def mark_auto_send_completed(app, event_id: str, kind: str) -> None:
+    col = await controls_collection(app)
+    await col.update_one(
+        {"_id": _control_id(event_id, kind)},
+        {
+            "$set": {
+                "event_id": event_id,
+                "kind": kind,
+                "auto_send_completed": True,
+                "auto_send_completed_at": datetime.now().isoformat(),
+            },
+            "$setOnInsert": {"paused": False, "admin_preview_sent": False},
+        },
+        upsert=True,
+    )
 
 
 async def iter_unpaid_for_reminders(app, event: dict) -> list[dict]:
-    event_id = str(event["_id"])
+    event_id = _event_id(event)
     cursor = app.collection.find(
         {
             "event_id": event_id,
@@ -20,64 +125,248 @@ async def iter_unpaid_for_reminders(app, event: dict) -> list[dict]:
     return await cursor.to_list(length=None)
 
 
+def _eligible_events(events: list[dict]) -> list[dict]:
+    out = []
+    for event in events:
+        status = event.get("status")
+        if status in ("archived", "passed"):
+            continue
+        if status in ("upcoming", "registration_closed", None) or event.get(
+            "enabled", True
+        ):
+            out.append(event)
+    return out
+
+
+async def build_reminder_batch(
+    app, event: dict, kind: str
+) -> tuple[list[dict], str]:
+    """Return (unpaid regs not yet messaged, message text)."""
+    city = event.get("city", "городе")
+    text = reminder_message(kind, event, city)
+    flag = KIND_FLAG[kind]
+    unpaid = await iter_unpaid_for_reminders(app, event)
+    targets = []
+    for reg in unpaid:
+        if reg.get(flag):
+            continue
+        if not reg.get("user_id"):
+            continue
+        targets.append(reg)
+    return targets, text
+
+
+def format_admin_preview(
+    event: dict,
+    kind: str,
+    targets: list[dict],
+    text: str,
+    *,
+    paused: bool,
+    send_date_display: str,
+) -> str:
+    city = event.get("city", "?")
+    label = kind_label_ru(kind)
+    names = []
+    for reg in targets[:40]:
+        uname = f"@{reg['username']}" if reg.get("username") else "—"
+        names.append(f"• {reg.get('full_name', '?')} ({uname})")
+    more = ""
+    if len(targets) > 40:
+        more = f"\n… и ещё {len(targets) - 40}"
+    pause_line = (
+        "⏸ <b>ПАУЗА</b> — авто-отправка не пойдёт, пока не снимете.\n"
+        if paused
+        else ""
+    )
+    return (
+        f"📋 <b>Завтра авто-напоминание</b> {label}\n"
+        f"Встреча: {city} · event {_event_id(event)[:8]}…\n"
+        f"Дата отправки пользователям: <b>{send_date_display}</b>\n"
+        f"{pause_line}"
+        f"Получателей (неоплатившие, ещё не слали): <b>{len(targets)}</b>\n"
+        f"{chr(10).join(names)}{more}\n\n"
+        f"——— полный текст ——-\n{text}\n\n"
+        "Админ → Управление → Напоминания об оплате: "
+        "пауза / снять паузу / отправить сейчас."
+    )
+
+
 async def send_payment_reminders(
     app,
     bot,
     *,
     now: Optional[datetime] = None,
     dry_run: bool = False,
+    force_kind: Optional[str] = None,
+    force_event_id: Optional[str] = None,
+    respect_pause: bool = True,
+    only_due_today: bool = True,
 ) -> dict[str, Any]:
-    """Scan upcoming events; send at most one D-4 and one D-2 per registration.
+    """Send D-4 / D-2 payment reminders.
 
-    Marks ``payment_reminder_d4_sent`` / ``payment_reminder_d2_sent`` on the reg.
+    *force_event_id* + *force_kind*: admin «send now» (ignores calendar day).
+    *only_due_today*: when True, only kinds due on *now*'s date (unless force).
     """
     now = now or datetime.now()
-    stats = {"events": 0, "d4": 0, "d2": 0, "errors": 0, "skipped": 0}
+    stats: dict[str, Any] = {
+        "events": 0,
+        "d4": 0,
+        "d2": 0,
+        "errors": 0,
+        "skipped": 0,
+        "paused": 0,
+    }
 
-    events = await app.get_all_events()
+    events = _eligible_events(await app.get_all_events())
     for event in events:
-        status = event.get("status")
-        if status in ("archived", "passed"):
-            continue
-        if not event.get("enabled", True) and status != "upcoming":
-            # still allow registration_closed if people need to pay
-            if status not in ("upcoming", "registration_closed"):
-                continue
-
-        kind = reminder_kind_for_event(event, now)
-        if not kind:
+        eid = _event_id(event)
+        if force_event_id and eid != force_event_id:
             continue
 
-        stats["events"] += 1
-        city = event.get("city", "городе")
-        text = reminder_message(kind, event, city)
-        flag = (
-            "payment_reminder_d4_sent" if kind == "d4" else "payment_reminder_d2_sent"
-        )
+        if force_kind:
+            kinds = [force_kind]
+        elif only_due_today:
+            k = reminder_kind_for_event(event, now)
+            kinds = [k] if k else []
+        else:
+            kinds = []
 
-        unpaid = await iter_unpaid_for_reminders(app, event)
-        for reg in unpaid:
-            if reg.get(flag):
+        for kind in kinds:
+            if respect_pause:
+                ctrl = await get_control(app, eid, kind)
+                if ctrl.get("paused"):
+                    stats["paused"] += 1
+                    logger.info(f"reminder {kind} paused for event {eid}")
+                    continue
+
+            stats["events"] += 1
+            targets, text = await build_reminder_batch(app, event, kind)
+            flag = KIND_FLAG[kind]
+            if not targets:
                 stats["skipped"] += 1
                 continue
-            user_id = reg.get("user_id")
-            if not user_id:
-                stats["skipped"] += 1
-                continue
-            if dry_run:
-                stats[kind] += 1
-                continue
-            try:
-                await bot.send_message(int(user_id), text)
-                await app.collection.update_one(
-                    {"_id": reg["_id"]},
-                    {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
-                )
-                stats[kind] += 1
-            except Exception as e:
-                stats["errors"] += 1
-                logger.warning(
-                    f"payment reminder {kind} failed for user {user_id}: {e}"
-                )
+
+            for reg in targets:
+                user_id = reg.get("user_id")
+                if dry_run:
+                    stats[kind] += 1
+                    continue
+                try:
+                    await bot.send_message(int(user_id), text)
+                    await app.collection.update_one(
+                        {"_id": reg["_id"]},
+                        {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
+                    )
+                    stats[kind] += 1
+                except Exception as e:
+                    stats["errors"] += 1
+                    logger.warning(
+                        f"payment reminder {kind} failed for user {user_id}: {e}"
+                    )
+
+            if not dry_run and not force_kind:
+                await mark_auto_send_completed(app, eid, kind)
 
     return stats
+
+
+async def send_admin_previews(
+    app,
+    *,
+    now: Optional[datetime] = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Day before each reminder: summary + full text to events/logs chat."""
+    now = now or datetime.now()
+    stats = {"previews": 0, "skipped": 0, "errors": 0}
+    events = _eligible_events(await app.get_all_events())
+
+    for event in events:
+        eid = _event_id(event)
+        for kind in admin_preview_kinds_for_event(event, now):
+            ctrl = await get_control(app, eid, kind)
+            if ctrl.get("admin_preview_sent"):
+                stats["skipped"] += 1
+                continue
+            targets, text = await build_reminder_batch(app, event, kind)
+            send_date = (now.date() + timedelta(days=1)).strftime("%d.%m.%Y")
+            body = format_admin_preview(
+                event,
+                kind,
+                targets,
+                text,
+                paused=bool(ctrl.get("paused")),
+                send_date_display=send_date,
+            )
+            if dry_run:
+                stats["previews"] += 1
+                continue
+            try:
+                sent = await app.log_to_chat(body, "events")
+                if sent is None:
+                    sent = await app.log_to_chat(body, "logs")
+                if sent is None:
+                    logger.warning(
+                        "admin reminder preview: no events/logs chat configured"
+                    )
+                    stats["errors"] += 1
+                    continue
+                await mark_admin_preview_sent(app, eid, kind)
+                stats["previews"] += 1
+            except Exception as e:
+                stats["errors"] += 1
+                logger.warning(f"admin preview failed event={eid} kind={kind}: {e}")
+
+    return stats
+
+
+async def list_upcoming_reminder_plan(
+    app, *, now: Optional[datetime] = None, days_ahead: int = 14
+) -> list[dict]:
+    """Plan rows for admin UI: next N days of previews + sends."""
+    from src.payment_timeline import badge_deadline, food_deadline
+
+    now = now or datetime.now()
+    plan = []
+    events = _eligible_events(await app.get_all_events())
+    for event in events:
+        eid = _event_id(event)
+        for kind, dl_fn in (("d4", food_deadline), ("d2", badge_deadline)):
+            dl = dl_fn(event)
+            if not dl:
+                continue
+            send_day = dl.date()
+            preview_day = send_day - timedelta(days=1)
+            if send_day < now.date() or send_day > now.date() + timedelta(
+                days=days_ahead
+            ):
+                continue
+            ctrl = await get_control(app, eid, kind)
+            targets, text = await build_reminder_batch(app, event, kind)
+            plan.append(
+                {
+                    "event_id": eid,
+                    "city": event.get("city", "?"),
+                    "kind": kind,
+                    "label": kind_label_ru(kind),
+                    "preview_day": preview_day.isoformat(),
+                    "send_day": send_day.isoformat(),
+                    "paused": bool(ctrl.get("paused")),
+                    "recipient_count": len(targets),
+                    "text": text,
+                }
+            )
+    plan.sort(key=lambda r: (r["send_day"], r["kind"]))
+    return plan
+
+
+async def daily_reminder_tick(app, bot, *, now: Optional[datetime] = None) -> dict:
+    """Scheduled job: admin previews for tomorrow + user sends due today."""
+    now = now or datetime.now()
+    preview_stats = await send_admin_previews(app, now=now, dry_run=False)
+    send_stats = await send_payment_reminders(
+        app, bot, now=now, dry_run=False, only_due_today=True, respect_pause=True
+    )
+    logger.info(f"payment reminder tick: previews={preview_stats} sends={send_stats}")
+    return {"preview": preview_stats, "send": send_stats}

--- a/src/payment_reminders.py
+++ b/src/payment_reminders.py
@@ -3,6 +3,7 @@
 Control state lives in Mongo collection ``payment_reminder_controls``
 (one doc per event_id + kind). Per-user send flags stay on registrations.
 """
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -138,9 +139,7 @@ def _eligible_events(events: list[dict]) -> list[dict]:
     return out
 
 
-async def build_reminder_batch(
-    app, event: dict, kind: str
-) -> tuple[list[dict], str]:
+async def build_reminder_batch(app, event: dict, kind: str) -> tuple[list[dict], str]:
     """Return (unpaid regs not yet messaged, message text)."""
     city = event.get("city", "городе")
     text = reminder_message(kind, event, city)
@@ -175,9 +174,7 @@ def format_admin_preview(
     if len(targets) > 40:
         more = f"\n… и ещё {len(targets) - 40}"
     pause_line = (
-        "⏸ <b>ПАУЗА</b> — авто-отправка не пойдёт, пока не снимете.\n"
-        if paused
-        else ""
+        "⏸ <b>ПАУЗА</b> — авто-отправка не пойдёт, пока не снимете.\n" if paused else ""
     )
     return (
         f"📋 <b>Завтра авто-напоминание</b> {label}\n"
@@ -190,6 +187,90 @@ def format_admin_preview(
         "Админ → Управление → Напоминания об оплате: "
         "пауза / снять паузу / отправить сейчас."
     )
+
+
+def _kinds_for_event(
+    event: dict,
+    *,
+    now: datetime,
+    force_kind: Optional[str],
+    only_due_today: bool,
+) -> list[str]:
+    if force_kind:
+        return [force_kind]
+    if only_due_today:
+        k = reminder_kind_for_event(event, now)
+        return [k] if k else []
+    return []
+
+
+async def _deliver_batch(
+    app,
+    bot,
+    *,
+    targets: list[dict],
+    text: str,
+    kind: str,
+    now: datetime,
+    dry_run: bool,
+    stats: dict[str, Any],
+) -> None:
+    flag = KIND_FLAG[kind]
+    for reg in targets:
+        user_id = reg.get("user_id")
+        if dry_run:
+            stats[kind] += 1
+            continue
+        try:
+            await bot.send_message(int(user_id), text)
+            await app.collection.update_one(
+                {"_id": reg["_id"]},
+                {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
+            )
+            stats[kind] += 1
+        except Exception as e:
+            stats["errors"] += 1
+            logger.warning(f"payment reminder {kind} failed for user {user_id}: {e}")
+
+
+async def _send_kind_for_event(
+    app,
+    bot,
+    event: dict,
+    kind: str,
+    *,
+    now: datetime,
+    dry_run: bool,
+    respect_pause: bool,
+    force_kind: Optional[str],
+    stats: dict[str, Any],
+) -> None:
+    eid = _event_id(event)
+    if respect_pause:
+        ctrl = await get_control(app, eid, kind)
+        if ctrl.get("paused"):
+            stats["paused"] += 1
+            logger.info(f"reminder {kind} paused for event {eid}")
+            return
+
+    stats["events"] += 1
+    targets, text = await build_reminder_batch(app, event, kind)
+    if not targets:
+        stats["skipped"] += 1
+        return
+
+    await _deliver_batch(
+        app,
+        bot,
+        targets=targets,
+        text=text,
+        kind=kind,
+        now=now,
+        dry_run=dry_run,
+        stats=stats,
+    )
+    if not dry_run and not force_kind:
+        await mark_auto_send_completed(app, eid, kind)
 
 
 async def send_payment_reminders(
@@ -218,55 +299,24 @@ async def send_payment_reminders(
         "paused": 0,
     }
 
-    events = _eligible_events(await app.get_all_events())
-    for event in events:
+    for event in _eligible_events(await app.get_all_events()):
         eid = _event_id(event)
         if force_event_id and eid != force_event_id:
             continue
-
-        if force_kind:
-            kinds = [force_kind]
-        elif only_due_today:
-            k = reminder_kind_for_event(event, now)
-            kinds = [k] if k else []
-        else:
-            kinds = []
-
-        for kind in kinds:
-            if respect_pause:
-                ctrl = await get_control(app, eid, kind)
-                if ctrl.get("paused"):
-                    stats["paused"] += 1
-                    logger.info(f"reminder {kind} paused for event {eid}")
-                    continue
-
-            stats["events"] += 1
-            targets, text = await build_reminder_batch(app, event, kind)
-            flag = KIND_FLAG[kind]
-            if not targets:
-                stats["skipped"] += 1
-                continue
-
-            for reg in targets:
-                user_id = reg.get("user_id")
-                if dry_run:
-                    stats[kind] += 1
-                    continue
-                try:
-                    await bot.send_message(int(user_id), text)
-                    await app.collection.update_one(
-                        {"_id": reg["_id"]},
-                        {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
-                    )
-                    stats[kind] += 1
-                except Exception as e:
-                    stats["errors"] += 1
-                    logger.warning(
-                        f"payment reminder {kind} failed for user {user_id}: {e}"
-                    )
-
-            if not dry_run and not force_kind:
-                await mark_auto_send_completed(app, eid, kind)
+        for kind in _kinds_for_event(
+            event, now=now, force_kind=force_kind, only_due_today=only_due_today
+        ):
+            await _send_kind_for_event(
+                app,
+                bot,
+                event,
+                kind,
+                now=now,
+                dry_run=dry_run,
+                respect_pause=respect_pause,
+                force_kind=force_kind,
+                stats=stats,
+            )
 
     return stats
 

--- a/src/payment_timeline.py
+++ b/src/payment_timeline.py
@@ -15,6 +15,9 @@ FOOD_DAYS_BEFORE = 4
 BADGE_DAYS_BEFORE = 2
 DEADLINE_HOUR = 6  # 06:00
 
+# Admin gets a summary 1 calendar day before each user-facing reminder day.
+ADMIN_PREVIEW_DAYS_BEFORE_REMINDER = 1
+
 
 def _as_date(value: Any) -> Optional[date]:
     if value is None:
@@ -35,7 +38,9 @@ def event_date(event: dict) -> Optional[date]:
     return _as_date(event.get("date"))
 
 
-def deadline_at(event: dict, days_before: int, hour: int = DEADLINE_HOUR) -> Optional[datetime]:
+def deadline_at(
+    event: dict, days_before: int, hour: int = DEADLINE_HOUR
+) -> Optional[datetime]:
     """Instant after which the “late” rule applies (06:00 on that morning)."""
     d = event_date(event)
     if d is None:
@@ -100,23 +105,47 @@ def pay_later_message(event: dict, now: Optional[datetime] = None) -> str:
     )
 
 
+def _deadline_for_kind(event: dict, kind: str) -> Optional[datetime]:
+    if kind == "d4":
+        return food_deadline(event)
+    if kind == "d2":
+        return badge_deadline(event)
+    raise ValueError(f"unknown reminder kind: {kind}")
+
+
 def reminder_kind_for_event(
     event: dict, now: Optional[datetime] = None
 ) -> Optional[str]:
     """Return ``d4`` or ``d2`` if *now* falls on that reminder calendar day.
 
     Reminder day = calendar day of the corresponding 06:00 deadline
-    (D-4 food planning day, D-2 badge day).
+    (D-4 food planning day, D-2 badge day). Prefer d4 if both somehow collide.
     """
     now = now or datetime.now()
+    today = now.date()
     food = food_deadline(event)
     badge = badge_deadline(event)
-    today = now.date()
     if food and today == food.date():
         return "d4"
     if badge and today == badge.date():
         return "d2"
     return None
+
+
+def admin_preview_kinds_for_event(
+    event: dict, now: Optional[datetime] = None
+) -> list[str]:
+    """Kinds whose user-reminder day is **tomorrow** (admin preview day)."""
+    now = now or datetime.now()
+    tomorrow = now.date() + timedelta(days=ADMIN_PREVIEW_DAYS_BEFORE_REMINDER)
+    kinds: list[str] = []
+    food = food_deadline(event)
+    badge = badge_deadline(event)
+    if food and tomorrow == food.date():
+        kinds.append("d4")
+    if badge and tomorrow == badge.date():
+        kinds.append("d2")
+    return kinds
 
 
 def reminder_message(kind: str, event: dict, city: str) -> str:
@@ -137,6 +166,14 @@ def reminder_message(kind: str, event: dict, city: str) -> str:
             "Оплатить: /pay. После оплаты пришлите скриншот в чат."
         )
     raise ValueError(f"unknown reminder kind: {kind}")
+
+
+def kind_label_ru(kind: str) -> str:
+    if kind == "d4":
+        return "D-4 (еда / 4 дня)"
+    if kind == "d2":
+        return "D-2 (бейдж / 2 дня)"
+    return kind
 
 
 VOLUNTEER_OPTIONS_TEXT = (

--- a/src/payment_timeline.py
+++ b/src/payment_timeline.py
@@ -4,6 +4,7 @@ Deadlines are at 06:00 on the calendar day N days before the event date
 (buffer: “before six in the morning”). Timezone-naive datetimes are treated
 as local wall time of the stored event date.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/reminder_scheduler.py
+++ b/src/reminder_scheduler.py
@@ -1,0 +1,63 @@
+"""APScheduler hook: daily payment reminder tick (admin preview + auto-send)."""
+from __future__ import annotations
+
+from typing import Optional
+
+from loguru import logger
+
+_scheduler = None
+
+
+def start_reminder_scheduler(app, bot, *, hour: int = 9, minute: int = 0) -> None:
+    """Start a singleton AsyncIOScheduler (no-op if already running)."""
+    global _scheduler
+    if _scheduler is not None:
+        logger.info("payment reminder scheduler already running")
+        return
+
+    try:
+        from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    except ImportError:
+        logger.error("apscheduler not installed; payment reminders will not auto-run")
+        return
+
+    from src.payment_reminders import daily_reminder_tick
+
+    scheduler = AsyncIOScheduler()
+
+    async def _job():
+        try:
+            await daily_reminder_tick(app, bot)
+        except Exception:
+            logger.exception("daily_reminder_tick failed")
+
+    scheduler.add_job(
+        _job,
+        trigger="cron",
+        hour=hour,
+        minute=minute,
+        id="payment_reminders_daily",
+        replace_existing=True,
+        misfire_grace_time=3600,
+    )
+    # Hourly safety net: same flags make it idempotent.
+    scheduler.add_job(
+        _job,
+        trigger="cron",
+        minute=15,
+        id="payment_reminders_hourly",
+        replace_existing=True,
+        misfire_grace_time=600,
+    )
+    scheduler.start()
+    _scheduler = scheduler
+    logger.info(
+        f"payment reminder scheduler started (daily {hour:02d}:{minute:02d} + hourly :15)"
+    )
+
+
+def stop_reminder_scheduler() -> None:
+    global _scheduler
+    if _scheduler is not None:
+        _scheduler.shutdown(wait=False)
+        _scheduler = None

--- a/src/reminder_scheduler.py
+++ b/src/reminder_scheduler.py
@@ -1,7 +1,7 @@
 """APScheduler hook: daily payment reminder tick (admin preview + auto-send)."""
+
 from __future__ import annotations
 
-from typing import Optional
 
 from loguru import logger
 

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -32,74 +32,59 @@ router = Router()
 # Helper function for calculating median
 
 
-async def admin_handler(message: Message, state: FSMContext, app: App):
+_ADMIN_SUBMENUS = {
+    "management": (
+        "Управление:",
+        {
+            "manage_events": "Управление встречами",
+            "register_payment": "Зарегистрировать оплату (за другого участника)",
+            "discretionary": "Скидка / бесплатный вход (решение Марии)",
+            "payment_reminders": "Напоминания об оплате (D-4 / D-2)",
+            "export": "Экспортировать данные",
+        },
+    ),
+    "communication": (
+        "Коммуникации:",
+        {
+            "notify_users": "Рассылка пользователям",
+            "announce_season": "Анонс нового сезона встреч",
+        },
+    ),
+    "stats": (
+        "Статистика и аналитика:",
+        {
+            "view_stats": "Статистика (подробно)",
+            "view_simple_stats": "Статистика (кратко)",
+            "view_year_stats": "По годам выпуска",
+            "five_year_stats": "По пятилеткам выпуска",
+            "payment_stats": "Диаграмма оплат",
+        },
+    ),
+}
+
+
+async def _resolve_admin_submenu(
+    chat_id: int, state: FSMContext, response: Optional[str]
+) -> Optional[str]:
+    if response not in _ADMIN_SUBMENUS:
+        return response
+    title, choices = _ADMIN_SUBMENUS[response]
+    return await ask_user_choice(
+        chat_id, title, choices=choices, state=state, timeout=None
+    )
+
+
+async def _dispatch_admin_action(
+    message: Message, state: FSMContext, app: App, response: Optional[str]
+) -> None:
     from src.routers.stats import (
-        show_stats,
-        show_simple_stats,
-        show_year_stats,
         show_five_year_stats,
         show_payment_stats,
+        show_simple_stats,
+        show_stats,
+        show_year_stats,
     )
 
-    response = await ask_user_choice(
-        message.chat.id,
-        "Вы администратор бота. Что вы хотите сделать?",
-        choices={
-            "register": "Протестировать бота (обычный сценарий)",
-            "management": "Управление",
-            "communication": "Коммуникации",
-            "stats": "Статистика и аналитика",
-        },
-        state=state,
-        timeout=None,
-    )
-
-    # -- Management submenu --
-    if response == "management":
-        response = await ask_user_choice(
-            message.chat.id,
-            "Управление:",
-            choices={
-                "manage_events": "Управление встречами",
-                "register_payment": "Зарегистрировать оплату (за другого участника)",
-                "discretionary": "Скидка / бесплатный вход (решение Марии)",
-                "payment_reminders": "Напоминания об оплате (D-4 / D-2)",
-                "export": "Экспортировать данные",
-            },
-            state=state,
-            timeout=None,
-        )
-
-    # -- Communication submenu --
-    if response == "communication":
-        response = await ask_user_choice(
-            message.chat.id,
-            "Коммуникации:",
-            choices={
-                "notify_users": "Рассылка пользователям",
-                "announce_season": "Анонс нового сезона встреч",
-            },
-            state=state,
-            timeout=None,
-        )
-
-    # -- Stats submenu --
-    if response == "stats":
-        response = await ask_user_choice(
-            message.chat.id,
-            "Статистика и аналитика:",
-            choices={
-                "view_stats": "Статистика (подробно)",
-                "view_simple_stats": "Статистика (кратко)",
-                "view_year_stats": "По годам выпуска",
-                "five_year_stats": "По пятилеткам выпуска",
-                "payment_stats": "Диаграмма оплат",
-            },
-            state=state,
-            timeout=None,
-        )
-
-    # -- Dispatch --
     if response == "manage_events":
         from src.routers.events import manage_events_handler
 
@@ -130,6 +115,23 @@ async def admin_handler(message: Message, state: FSMContext, app: App):
         await show_five_year_stats(message, app=app)
     elif response == "payment_stats":
         await show_payment_stats(message, app=app)
+
+
+async def admin_handler(message: Message, state: FSMContext, app: App):
+    response = await ask_user_choice(
+        message.chat.id,
+        "Вы администратор бота. Что вы хотите сделать?",
+        choices={
+            "register": "Протестировать бота (обычный сценарий)",
+            "management": "Управление",
+            "communication": "Коммуникации",
+            "stats": "Статистика и аналитика",
+        },
+        state=state,
+        timeout=None,
+    )
+    response = await _resolve_admin_submenu(message.chat.id, state, response)
+    await _dispatch_admin_action(message, state, app, response)
     # For "register", continue with normal flow
     return response
 

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -109,7 +109,7 @@ async def admin_handler(message: Message, state: FSMContext, app: App):
     elif response == "discretionary":
         await admin_discretionary_payment(message, state, app)
     elif response == "payment_reminders":
-        await admin_run_payment_reminders(message, app)
+        await admin_payment_reminders_menu(message, state, app)
     elif response == "export":
         await export_handler(message, state, app=app)
     elif response == "notify_users":
@@ -431,31 +431,201 @@ async def admin_discretionary_payment(
     await app.export_registered_users_to_google_sheets()
 
 
-async def admin_run_payment_reminders(message: Message, app: App) -> None:
-    """Run D-4 / D-2 payment reminder scan (idempotent flags on registrations)."""
+async def admin_payment_reminders_menu(
+    message: Message, state: FSMContext, app: App
+) -> None:
+    """Admin tools: plan, pause/unpause, send now, force daily tick."""
+    chat_id = message.chat.id
+    action = await ask_user_choice(
+        chat_id,
+        "Напоминания об оплате (D-4 еда / D-2 бейдж).\n"
+        "Авто: ежедневно ~09:00 + hourly; за день — превью админам.",
+        choices={
+            "plan": "Расписание / превью ближайших",
+            "pause": "Пауза (не слать автоматически)",
+            "unpause": "Снять паузу",
+            "send_now": "Отправить сейчас (выбрать встречу)",
+            "tick": "Запустить тик сейчас (превью+должные)",
+            "cancel": "Назад",
+        },
+        state=state,
+        timeout=None,
+    )
+    if action in (None, "cancel"):
+        await send_safe(chat_id, "Ок.")
+        return
+    if action == "plan":
+        await _admin_reminders_show_plan(message, app)
+    elif action == "pause":
+        await _admin_reminders_set_pause(message, state, app, paused=True)
+    elif action == "unpause":
+        await _admin_reminders_set_pause(message, state, app, paused=False)
+    elif action == "send_now":
+        await _admin_reminders_send_now(message, state, app)
+    elif action == "tick":
+        await admin_run_payment_reminders(message, app)
+
+
+async def _admin_reminders_show_plan(message: Message, app: App) -> None:
+    from src.payment_reminders import list_upcoming_reminder_plan
+
+    plan = await list_upcoming_reminder_plan(app, days_ahead=14)
+    if not plan:
+        await send_safe(message.chat.id, "В ближайшие 14 дней напоминаний не запланировано.")
+        return
+    lines = ["📅 Ближайшие авто-напоминания:\n"]
+    for row in plan:
+        pause = " ⏸" if row["paused"] else ""
+        lines.append(
+            f"• {row['send_day']} {row['label']}{pause} — {row['city']}\n"
+            f"  превью админам: {row['preview_day']} · "
+            f"получателей ~{row['recipient_count']}\n"
+            f"  id={row['event_id'][:10]}…"
+        )
+    # First full text preview (so admins see copy)
+    first = plan[0]
+    lines.append("\n——— пример текста (первый в списке) ——-")
+    lines.append(first["text"])
+    await send_safe(message.chat.id, "\n".join(lines))
+
+
+async def _pick_event_and_kind(
+    chat_id: int, state: FSMContext, app: App, plan_only: bool = False
+) -> Optional[tuple[str, str, str]]:
+    """Returns (event_id, kind, city) or None."""
+    from src.payment_reminders import list_upcoming_reminder_plan
+    from src.payment_timeline import kind_label_ru
+
+    if plan_only:
+        plan = await list_upcoming_reminder_plan(app, days_ahead=30)
+        if not plan:
+            await send_safe(chat_id, "Нет предстоящих напоминаний.")
+            return None
+        choices = {}
+        for i, row in enumerate(plan):
+            key = f"{i}"
+            pause = " ⏸" if row["paused"] else ""
+            choices[key] = (
+                f"{row['send_day']} {row['label']}{pause} — {row['city']} "
+                f"({row['recipient_count']} чел.)"
+            )
+        choices["cancel"] = "Отмена"
+        pick = await ask_user_choice(
+            chat_id, "Выберите напоминание:", choices=choices, state=state, timeout=None
+        )
+        if pick in (None, "cancel"):
+            return None
+        row = plan[int(pick)]
+        return row["event_id"], row["kind"], row["city"]
+
+    # All non-archived events × kinds
+    selected = await _select_event_for_payment(chat_id, state, app)
+    if not selected:
+        return None
+    event = await app.get_event_by_id(selected)
+    city = (event or {}).get("city", "?")
+    kind = await ask_user_choice(
+        chat_id,
+        f"{city}: какой тип?",
+        choices={
+            "d4": kind_label_ru("d4"),
+            "d2": kind_label_ru("d2"),
+            "cancel": "Отмена",
+        },
+        state=state,
+        timeout=None,
+    )
+    if kind in (None, "cancel"):
+        return None
+    return selected, kind, city
+
+
+async def _admin_reminders_set_pause(
+    message: Message, state: FSMContext, app: App, *, paused: bool
+) -> None:
+    from src.payment_reminders import set_paused
+    from src.payment_timeline import kind_label_ru
+
+    pick = await _pick_event_and_kind(message.chat.id, state, app, plan_only=True)
+    if not pick:
+        await send_safe(message.chat.id, "Отменено.")
+        return
+    event_id, kind, city = pick
+    ctrl = await set_paused(app, event_id, kind, paused)
+    state_ru = "на паузе ⏸" if ctrl.get("paused") else "активно ▶"
+    await send_safe(
+        message.chat.id,
+        f"{city} · {kind_label_ru(kind)}: теперь <b>{state_ru}</b>.",
+    )
+
+
+async def _admin_reminders_send_now(
+    message: Message, state: FSMContext, app: App
+) -> None:
     from botspot.core.dependency_manager import get_dependency_manager
     from src.payment_reminders import send_payment_reminders
+    from src.payment_timeline import kind_label_ru
+
+    pick = await _pick_event_and_kind(message.chat.id, state, app, plan_only=False)
+    if not pick:
+        await send_safe(message.chat.id, "Отменено.")
+        return
+    event_id, kind, city = pick
+    confirm = await ask_user_choice(
+        message.chat.id,
+        f"Отправить <b>сейчас</b> {kind_label_ru(kind)} для {city} "
+        f"(только тем, кому ещё не слали; пауза игнорируется)?",
+        choices={"yes": "Да, отправить", "no": "Отмена"},
+        state=state,
+        timeout=None,
+    )
+    if confirm != "yes":
+        await send_safe(message.chat.id, "Отменено.")
+        return
+    bot = get_dependency_manager().bot
+    stats = await send_payment_reminders(
+        app,
+        bot,
+        force_event_id=event_id,
+        force_kind=kind,
+        respect_pause=False,
+        only_due_today=False,
+    )
+    await send_safe(
+        message.chat.id,
+        f"Отправлено сейчас ({kind_label_ru(kind)} / {city}):\n"
+        f"d4={stats['d4']} d2={stats['d2']} "
+        f"skipped={stats['skipped']} errors={stats['errors']}",
+    )
+
+
+async def admin_run_payment_reminders(message: Message, app: App) -> None:
+    """Force daily tick: admin previews + due user sends (respects pause)."""
+    from botspot.core.dependency_manager import get_dependency_manager
+    from src.payment_reminders import daily_reminder_tick
 
     chat_id = message.chat.id
     await send_safe(
         chat_id,
-        "Запускаю проверку напоминаний (D-4 еда / D-2 бейдж)…",
+        "Запускаю тик: превью «завтра» + рассылка должных на сегодня…",
     )
     try:
         bot = get_dependency_manager().bot
-        stats = await send_payment_reminders(app, bot, dry_run=False)
+        result = await daily_reminder_tick(app, bot)
     except Exception as e:
-        logger.exception("payment reminders failed")
+        logger.exception("payment reminders tick failed")
         await send_safe(chat_id, f"Ошибка: {e}")
         return
+    prev = result["preview"]
+    send = result["send"]
     await send_safe(
         chat_id,
-        "Напоминания:\n"
-        f"• событий в окне D-4/D-2: {stats['events']}\n"
-        f"• отправлено D-4: {stats['d4']}\n"
-        f"• отправлено D-2: {stats['d2']}\n"
-        f"• пропущено (уже слали / нет user_id): {stats['skipped']}\n"
-        f"• ошибок: {stats['errors']}",
+        "Тик готов.\n"
+        f"Превью админам: {prev.get('previews', 0)} "
+        f"(skip {prev.get('skipped', 0)}, err {prev.get('errors', 0)})\n"
+        f"Пользователям: d4={send.get('d4', 0)} d2={send.get('d2', 0)} "
+        f"paused={send.get('paused', 0)} skipped={send.get('skipped', 0)} "
+        f"errors={send.get('errors', 0)}",
     )
 
 

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -471,7 +471,9 @@ async def _admin_reminders_show_plan(message: Message, app: App) -> None:
 
     plan = await list_upcoming_reminder_plan(app, days_ahead=14)
     if not plan:
-        await send_safe(message.chat.id, "В ближайшие 14 дней напоминаний не запланировано.")
+        await send_safe(
+            message.chat.id, "В ближайшие 14 дней напоминаний не запланировано."
+        )
         return
     lines = ["📅 Ближайшие авто-напоминания:\n"]
     for row in plan:

--- a/src/routers/crm.py
+++ b/src/routers/crm.py
@@ -408,28 +408,10 @@ async def _send_announcements(users_ids: list, announcement_text: str) -> tuple:
     return sent_count, failed_count
 
 
-async def announce_new_season_handler(message: Message, state: FSMContext, app: App):
-    """Announce new meetup season to users with audience and city controls."""
-    if not message.from_user:
-        await send_safe(message.chat.id, "❌ Ошибка: не удалось определить отправителя")
-        return
-
-    enabled_events = await app.get_enabled_events()
-    if not enabled_events:
-        await send_safe(
-            message.chat.id,
-            "⚠️ Нет активных встреч. Сначала создайте встречи через /create_event",
-        )
-        return
-
-    events_preview = "📅 Текущие активные встречи:\n"
-    for ev in enabled_events:
-        from src.router import get_event_date_display
-
-        events_preview += f"  • {ev.get('city', '?')} ({get_event_date_display(ev)})\n"
-    await send_safe(message.chat.id, events_preview)
-
-    # Step 1: audience scope
+async def _season_collect_audience(
+    message: Message, state: FSMContext, app: App, enabled_events: list
+) -> Optional[tuple]:
+    """Return (audience, city_filter, event_map, user_ids) or None if cancelled."""
     audience = await ask_user_choice(
         message.chat.id,
         "Шаг 1: Кому отправить анонс?",
@@ -443,9 +425,8 @@ async def announce_new_season_handler(message: Message, state: FSMContext, app: 
     )
     if audience == "cancel":
         await send_safe(message.chat.id, "Операция отменена.")
-        return
+        return None
 
-    # Step 2: city/event filter
     city_choices: Dict[str, Any] = {"all": "Все города / встречи", "cancel": "Отмена"}
     event_map = {}
     for ev in enabled_events:
@@ -462,14 +443,52 @@ async def announce_new_season_handler(message: Message, state: FSMContext, app: 
     )
     if city_filter == "cancel":
         await send_safe(message.chat.id, "Операция отменена.")
-        return
+        return None
 
     target_user_ids = await _build_recipient_list(app, audience, city_filter, event_map)
     if not target_user_ids:
         await send_safe(message.chat.id, "❌ Нет пользователей для рассылки.")
+        return None
+    return audience, city_filter, event_map, target_user_ids
+
+
+def _season_audience_desc(audience: str, city_filter: str, event_map: dict) -> str:
+    desc = (
+        "все пользователи за всё время"
+        if audience == "all_time"
+        else "текущие зарегистрированные"
+    )
+    if city_filter != "all" and city_filter in event_map:
+        desc += f" ({event_map[city_filter].get('city', city_filter)})"
+    return desc
+
+
+async def announce_new_season_handler(message: Message, state: FSMContext, app: App):
+    """Announce new meetup season to users with audience and city controls."""
+    if not message.from_user:
+        await send_safe(message.chat.id, "❌ Ошибка: не удалось определить отправителя")
         return
 
-    # Step 3: link
+    enabled_events = await app.get_enabled_events()
+    if not enabled_events:
+        await send_safe(
+            message.chat.id,
+            "⚠️ Нет активных встреч. Сначала создайте встречи через /create_event",
+        )
+        return
+
+    from src.router import get_event_date_display
+
+    events_preview = "📅 Текущие активные встречи:\n"
+    for ev in enabled_events:
+        events_preview += f"  • {ev.get('city', '?')} ({get_event_date_display(ev)})\n"
+    await send_safe(message.chat.id, events_preview)
+
+    collected = await _season_collect_audience(message, state, app, enabled_events)
+    if collected is None:
+        return
+    audience, city_filter, event_map, target_user_ids = collected
+
     link_resp = await ask_user_raw(
         message.chat.id,
         "Шаг 3: Введите ссылку на пост (или 'нет' чтобы пропустить):",
@@ -480,21 +499,13 @@ async def announce_new_season_handler(message: Message, state: FSMContext, app: 
     if link_resp and link_resp.text and link_resp.text.strip().lower() != "нет":
         post_link = link_resp.text.strip()
 
-    default_message = _build_default_announcement(enabled_events, post_link)
-
-    # Step 4: text
-    announcement_text = await _get_announcement_text(message, state, default_message)
+    announcement_text = await _get_announcement_text(
+        message, state, _build_default_announcement(enabled_events, post_link)
+    )
     if announcement_text is None:
         return
 
-    audience_desc = (
-        "все пользователи за всё время"
-        if audience == "all_time"
-        else "текущие зарегистрированные"
-    )
-    if city_filter != "all" and city_filter in event_map:
-        audience_desc += f" ({event_map[city_filter].get('city', city_filter)})"
-
+    audience_desc = _season_audience_desc(audience, city_filter, event_map)
     confirm = await ask_user_confirmation(
         message.chat.id,
         f"⚠️ Отправить анонс {len(target_user_ids)} пользователям?\n"
@@ -519,7 +530,6 @@ async def announce_new_season_handler(message: Message, state: FSMContext, app: 
     sent_count, failed_count = await _send_announcements(
         target_user_ids, announcement_text
     )
-
     await status_msg.edit_text(
         f"✅ Анонс отправлен!\n\n"
         f"📊 Статистика:\n"

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -458,7 +458,9 @@ async def _handle_too_expensive(
                         "events",
                     )
                 except Exception as e:
-                    logger.warning(f"Could not log volunteer interest to events chat: {e}")
+                    logger.warning(
+                        f"Could not log volunteer interest to events chat: {e}"
+                    )
                 await send_safe(
                     message.chat.id,
                     "Отметили интерес. Напишите @mariikors — она решает "

--- a/src/templates.py
+++ b/src/templates.py
@@ -169,40 +169,31 @@ class _HtmlChecker(HTMLParser):
         return self
 
 
-def validate_template(spec: TemplateSpec, text: str) -> List[str]:
-    """Admin-facing reasons the text is unusable. Empty list means it's fine."""
-    errors: List[str] = []
-
-    if not text.strip():
-        errors.append("Текст не может быть пустым.")
-        return errors
-
+def _validate_placeholders(spec: TemplateSpec, text: str, errors: List[str]) -> None:
     used = set(PLACEHOLDER_RE.findall(text))
     unknown = used - spec.placeholders
     if unknown:
         allowed = ", ".join("{" + p + "}" for p in sorted(spec.placeholders))
         got = ", ".join("{" + p + "}" for p in sorted(unknown))
         errors.append(f"Неизвестные подстановки: {got}. Доступны: {allowed}")
-
     missing = spec.placeholders - used
     if missing:
         required = ", ".join("{" + p + "}" for p in sorted(missing))
         errors.append(f"Обязательные подстановки пропущены: {required}")
-
-    # A lone "{" or "}" that isn't part of a placeholder is almost always a typo
-    # that would silently ship to users as a stray brace.
+    # Lone braces that aren't placeholders are almost always typos.
     without = PLACEHOLDER_RE.sub("", text)
     if "{" in without or "}" in without:
         errors.append("Непарная скобка { или }. Подстановки пишутся как {name}.")
 
+
+def _validate_html_markup(text: str, errors: List[str]) -> None:
     checker = _HtmlChecker()
     try:
         checker.feed(text)
         checker.finish()
     except Exception as e:  # pragma: no cover - HTMLParser is lenient
         errors.append(f"Не удалось разобрать HTML: {e}")
-        return errors
-
+        return
     if checker.bad_tags:
         tags = ", ".join(sorted(set(checker.bad_tags)))
         errors.append(
@@ -224,6 +215,14 @@ def validate_template(spec: TemplateSpec, text: str) -> List[str]:
     if checker.stray_close:
         errors.append(f"Лишние закрывающие теги: {', '.join(checker.stray_close)}")
 
+
+def validate_template(spec: TemplateSpec, text: str) -> List[str]:
+    """Admin-facing reasons the text is unusable. Empty list means it's fine."""
+    if not text.strip():
+        return ["Текст не может быть пустым."]
+    errors: List[str] = []
+    _validate_placeholders(spec, text, errors)
+    _validate_html_markup(text, errors)
     return errors
 
 

--- a/src/user_interactions.py
+++ b/src/user_interactions.py
@@ -97,6 +97,36 @@ class UserInputManager:
 input_manager = UserInputManager()
 
 
+async def _cleanup_prompt_messages(
+    sent_message: Message,
+    request: "PendingRequest",
+    *,
+    cleanup: bool,
+) -> None:
+    if cleanup:
+        await sent_message.delete()
+        if request.raw_response:
+            await request.raw_response.delete()
+    elif sent_message.reply_markup:
+        await sent_message.edit_text(text=sent_message.text or "", reply_markup=None)
+
+
+async def _handle_ask_timeout(
+    sent_message: Message,
+    question: str,
+    *,
+    notify_on_timeout: bool,
+    default_choice: Optional[str],
+) -> Optional[str]:
+    if notify_on_timeout:
+        if default_choice is not None:
+            question += f"\n\n⏰ Auto-selected: {default_choice}"
+        else:
+            question += "\n\n⏰ No response received within the time limit."
+        await sent_message.edit_text(question)
+    return default_choice
+
+
 async def _ask_user_base(
     chat_id: int,
     question: str,
@@ -115,18 +145,15 @@ async def _ask_user_base(
 
     if not question or question.strip() == "":
         raise ValueError("Message text cannot be empty")
-
-    deps = get_dependency_manager()
-    bot: Bot = deps.bot
-
-    handler_id = f"ask_{datetime.now().timestamp()}"
-
     if default_choice is not None and return_raw:
         raise ValueError("Cannot return default choice when return_raw is True")
 
+    deps = get_dependency_manager()
+    bot: Bot = deps.bot
+    handler_id = f"ask_{datetime.now().timestamp()}"
+
     await state.set_state(UserInputState.waiting)
     await state.update_data(handler_id=handler_id)
-
     request = input_manager.add_request(
         chat_id,
         handler_id,
@@ -148,28 +175,17 @@ async def _ask_user_base(
 
     try:
         await asyncio.wait_for(request.event.wait(), timeout=timeout)
-        if cleanup:
-            await sent_message.delete()
-            if request.raw_response:
-                await request.raw_response.delete()
-        elif sent_message.reply_markup:
-            await sent_message.edit_text(
-                text=sent_message.text or "", reply_markup=None
-            )
-
-        return (
-            request.raw_response
-            if (return_raw and request.raw_response is not None)
-            else request.response
-        )
+        await _cleanup_prompt_messages(sent_message, request, cleanup=cleanup)
+        if return_raw and request.raw_response is not None:
+            return request.raw_response
+        return request.response
     except asyncio.TimeoutError:
-        if notify_on_timeout:
-            if default_choice is not None:
-                question += f"\n\n⏰ Auto-selected: {default_choice}"
-            else:
-                question += "\n\n⏰ No response received within the time limit."
-            await sent_message.edit_text(question)
-        return default_choice
+        return await _handle_ask_timeout(
+            sent_message,
+            question,
+            notify_on_timeout=notify_on_timeout,
+            default_choice=default_choice,
+        )
     finally:
         input_manager.remove_request(chat_id, handler_id)
         await state.clear()

--- a/tests/test_payment_reminders.py
+++ b/tests/test_payment_reminders.py
@@ -1,10 +1,16 @@
 """Tests for payment reminder selection (no real bot sends)."""
 from datetime import date, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.payment_reminders import send_payment_reminders
+from src.payment_reminders import (
+    daily_reminder_tick,
+    format_admin_preview,
+    send_admin_previews,
+    send_payment_reminders,
+)
+from src.payment_timeline import admin_preview_kinds_for_event
 
 
 @pytest.mark.asyncio
@@ -34,9 +40,19 @@ async def test_send_payment_reminders_d4_marks_flag():
     bot = MagicMock()
     bot.send_message = AsyncMock()
 
-    stats = await send_payment_reminders(
-        app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
-    )
+    with (
+        patch(
+            "src.payment_reminders.get_control",
+            new=AsyncMock(return_value={"paused": False}),
+        ),
+        patch(
+            "src.payment_reminders.mark_auto_send_completed",
+            new=AsyncMock(),
+        ),
+    ):
+        stats = await send_payment_reminders(
+            app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
+        )
     assert stats["d4"] == 1
     assert stats["d2"] == 0
     bot.send_message.assert_awaited_once()
@@ -68,9 +84,158 @@ async def test_send_payment_reminders_skips_already_sent():
     bot = MagicMock()
     bot.send_message = AsyncMock()
 
-    stats = await send_payment_reminders(
-        app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
-    )
+    with patch(
+        "src.payment_reminders.get_control",
+        new=AsyncMock(return_value={"paused": False}),
+    ):
+        stats = await send_payment_reminders(
+            app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
+        )
     assert stats["skipped"] == 1
     assert stats["d4"] == 0
     bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_payment_reminders_respects_pause():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    with patch(
+        "src.payment_reminders.get_control",
+        new=AsyncMock(return_value={"paused": True}),
+    ):
+        stats = await send_payment_reminders(
+            app, bot, now=datetime(2026, 7, 28, 9, 0)
+        )
+    assert stats["paused"] == 1
+    bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_force_send_now_ignores_calendar_and_pause():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    reg = {
+        "_id": "reg1",
+        "user_id": 7,
+        "event_id": "evt1",
+        "payment_status": "not paid",
+    }
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    app.collection.find = MagicMock(
+        return_value=MagicMock(to_list=AsyncMock(return_value=[reg]))
+    )
+    app.collection.update_one = AsyncMock()
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    # Not the reminder day (July 20), but force d4
+    stats = await send_payment_reminders(
+        app,
+        bot,
+        now=datetime(2026, 7, 20, 12, 0),
+        force_event_id="evt1",
+        force_kind="d4",
+        respect_pause=False,
+        only_due_today=False,
+    )
+    assert stats["d4"] == 1
+    bot.send_message.assert_awaited_once()
+
+
+def test_admin_preview_kinds_day_before_reminder():
+    event = {"date": date(2026, 8, 1), "city": "Пермь"}
+    # D-4 send day = Jul 28 → preview Jul 27
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 27, 10)) == [
+        "d4"
+    ]
+    # D-2 send day = Jul 30 → preview Jul 29
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 29, 10)) == [
+        "d2"
+    ]
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 28, 10)) == []
+
+
+def test_format_admin_preview_includes_text_and_recipients():
+    event = {"_id": "aabbccddeeff001122334455", "city": "Пермь", "date": date(2026, 8, 1)}
+    targets = [{"full_name": "Иван", "username": "ivan"}]
+    text = "Hello body"
+    msg = format_admin_preview(
+        event, "d4", targets, text, paused=True, send_date_display="28.07.2026"
+    )
+    assert "Завтра" in msg
+    assert "ПАУЗА" in msg
+    assert "Иван" in msg
+    assert "Hello body" in msg
+
+
+@pytest.mark.asyncio
+async def test_send_admin_previews_marks_sent():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    reg = {"_id": "r1", "user_id": 1, "full_name": "A", "username": "a"}
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    app.collection.find = MagicMock(
+        return_value=MagicMock(to_list=AsyncMock(return_value=[reg]))
+    )
+    app.log_to_chat = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "src.payment_reminders.get_control",
+            new=AsyncMock(return_value={"paused": False, "admin_preview_sent": False}),
+        ),
+        patch(
+            "src.payment_reminders.mark_admin_preview_sent",
+            new=AsyncMock(),
+        ) as mark,
+    ):
+        stats = await send_admin_previews(
+            app, now=datetime(2026, 7, 27, 9, 0), dry_run=False
+        )
+    assert stats["previews"] == 1
+    app.log_to_chat.assert_awaited()
+    mark.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_daily_tick_calls_both():
+    app = MagicMock()
+    bot = MagicMock()
+    with (
+        patch(
+            "src.payment_reminders.send_admin_previews",
+            new=AsyncMock(return_value={"previews": 1}),
+        ) as p,
+        patch(
+            "src.payment_reminders.send_payment_reminders",
+            new=AsyncMock(return_value={"d4": 2}),
+        ) as s,
+    ):
+        out = await daily_reminder_tick(app, bot, now=datetime(2026, 7, 27, 9))
+    assert out["preview"]["previews"] == 1
+    assert out["send"]["d4"] == 2
+    p.assert_awaited_once()
+    s.assert_awaited_once()

--- a/tests/test_payment_timeline.py
+++ b/tests/test_payment_timeline.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from src.payment_timeline import (
     BADGE_DAYS_BEFORE,
     FOOD_DAYS_BEFORE,
+    admin_preview_kinds_for_event,
     badge_deadline,
     food_deadline,
     pay_later_message,
@@ -67,3 +68,10 @@ def test_reminder_and_too_expensive_copy():
     cancel = too_expensive_cancel_message()
     assert "@mariikors" in cancel
     assert "волонт" in cancel.lower() or "Волонт" in cancel
+
+
+def test_admin_preview_is_day_before_send():
+    event = _event(date(2026, 8, 1))
+    # send d4 on 28 Jul → preview 27 Jul
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 27, 8)) == ["d4"]
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 28, 8)) == []


### PR DESCRIPTION
## Summary
- Automatic D-4 / D-2 reminders via APScheduler (daily 09:00 + hourly :15, idempotent)
- **1 day before** each send: admins get summary (who, count, pause state) + full message text (events/logs chat)
- Admin → Управление → Напоминания: plan, pause, unpause, send now, run tick now
- Pause stored in Mongo `payment_reminder_controls` per event+kind

## Test plan
- [x] pytest timeline/reminders/payment/admin (96 passed)
- [ ] Deploy TEST bot; confirm scheduler starts in logs
- [ ] Admin plan view; pause → tick skips; unpause; send now