### PR TITLE
Merge pay UX improvements into dev

### DIFF
--- a/docs/paid-ticket-contract.md
+++ b/docs/paid-ticket-contract.md
@@ -21,7 +21,7 @@ must return these fields:
 {
   "schema_version": 1,
   "payment_status": "confirmed",
-  "payment_kind": "event_attendance_donation",
+  "payment_kind": "event_attendance_payment",
   "bot_registration_id": "Mongo registered_users._id",
   "telegram_user_id": 123456789,
   "bot_event_id": "Mongo events._id",
@@ -70,6 +70,10 @@ Bot validation before writing `confirmed`:
    prefers it over the transitional visual code.
 7. Every `ticket_verification_url` must be HTTPS and contain a signed, revocable,
    non-personal token. Add it as a QR code in a later additive slice.
+8. `payment_kind` remains the accounting-neutral `event_attendance_payment`.
+   Petr calls this a donation in user-facing copy, but it must not enter generic
+   donation, endowment, or fundraising totals until Club 146 accounting confirms
+   its classification.
 
 The intent-creation request from bot to website needs the same three binding
 IDs (`bot_registration_id`, `telegram_user_id`, `bot_event_id`),

--- a/docs/paid-ticket-contract.md
+++ b/docs/paid-ticket-contract.md
@@ -1,0 +1,78 @@
+# Paid entry ticket contract
+
+Current TEST-first gate:
+
+- The bot sends/resends a personalized card only when the matching Mongo
+  registration has the exact value `payment_status == "confirmed"`.
+- `pending`, `declined`, missing status, and legacy unpaid strings never receive
+  a card.
+- `/status` is the recovery path. The existing admin receipt-confirmation path
+  sends the card immediately and `/status` can resend it later.
+- The fallback `146-XXXX-XXXX-XXXX` code is derived deterministically from the
+  bot registration ID, bot event ID, and Telegram user ID. It is a visual
+  registration reference, not cryptographic proof. Door staff must pair it
+  with the person's name and the bot's confirmed-registration list.
+
+The website payment bridge can be added without changing the renderer. After a
+signed CloudPayments webhook becomes authoritative, its bot-facing status API
+must return these fields:
+
+```json
+{
+  "schema_version": 1,
+  "payment_status": "confirmed",
+  "payment_kind": "event_attendance_donation",
+  "bot_registration_id": "Mongo registered_users._id",
+  "telegram_user_id": 123456789,
+  "bot_event_id": "Mongo events._id",
+  "website_event_uid": "stable Event.uid",
+  "amount_minor": 250000,
+  "currency": "RUB",
+  "paid_at": "2026-07-20T12:34:56Z",
+  "provider_payment_id": "opaque provider transaction id",
+  "admissions": [
+    {
+      "admission_id": "stable opaque id",
+      "role": "registrant",
+      "display_name": "Лавров Петр",
+      "ticket_code": "opaque uppercase code",
+      "ticket_verification_url": "https://146.school/tickets/verify/opaque-token"
+    },
+    {
+      "admission_id": "stable opaque id for guest 1",
+      "role": "guest",
+      "guest_index": 0,
+      "display_name": "Имя гостя",
+      "ticket_code": "different opaque uppercase code",
+      "ticket_verification_url": "https://146.school/tickets/verify/another-token"
+    }
+  ]
+}
+```
+
+Bot validation before writing `confirmed`:
+
+1. `bot_registration_id`, `telegram_user_id`, and `bot_event_id` must all match
+   one existing registration; never match by name, username, or email.
+2. `website_event_uid` must equal the bot event's future
+   `website_event_uid` field.
+3. Amount/currency must equal the immutable payment intent; browser-return
+   query parameters are never authoritative.
+4. `provider_payment_id` must be idempotent. A repeated webhook/status response
+   must not add payment twice or issue a second ticket.
+5. Only `payment_status: confirmed` unlocks admission. The website returns one
+   `admissions` item per human: registrant plus each named guest. Admission IDs
+   and ticket codes must be distinct so check-in, attendance, and later profile
+   achievements remain person-specific.
+6. For the immediate pre-website bridge, the bot renders one group-style card
+   containing the registrant and up to three current guest names. The bot stores
+   a future primary `ticket_code` on the registration; the renderer automatically
+   prefers it over the transitional visual code.
+7. Every `ticket_verification_url` must be HTTPS and contain a signed, revocable,
+   non-personal token. Add it as a QR code in a later additive slice.
+
+The intent-creation request from bot to website needs the same three binding
+IDs (`bot_registration_id`, `telegram_user_id`, `bot_event_id`),
+`website_event_uid`, immutable `amount_minor`/`currency`, attendee name, and an
+email only if CloudPayments requires it. Event, amount, purpose, and payment
+frequency must not be editable through public URL parameters.

--- a/example.env
+++ b/example.env
@@ -3,6 +3,9 @@ TELEGRAM_BOT_TOKEN=your_bot_token_here
 
 # ANTHROPIC API key for litellm (used for payment parsing)
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+# Vision model for receipt amount + Maria-vs-site detection (litellm id).
+# Default: sonnet (haiku was cheaper but misclassified receipts).
+# PAYMENT_PARSE_MODEL=anthropic/claude-sonnet-4-6
 
 
 # Required for Google Sheets export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "python-dotenv",
     "pydantic>=2.10.6",
     "pydantic-settings>=2.7.1",
+    "pillow>=12.1.1,<13",
     # Data visualization
     "matplotlib>=3.8.3",
     "seaborn>=0.13.1",

--- a/src/app.py
+++ b/src/app.py
@@ -497,8 +497,10 @@ class App:
         return await cursor.to_list(length=None)
 
     async def get_user_registration(self, user_id: int):
-        """Get existing registration for a user (returns first one found)"""
-        registrations = await self.get_user_registrations(user_id)
+        """Get the user's most recent registration (newest row wins, so old
+        seasons don't leak stale profile data into new registrations)."""
+        cursor = self.collection.find({"user_id": user_id}).sort("_id", -1)
+        registrations = await cursor.to_list(length=1)
         return registrations[0] if registrations else None
 
     async def delete_user_registration(

--- a/src/app.py
+++ b/src/app.py
@@ -503,6 +503,19 @@ class App:
         registrations = await cursor.to_list(length=1)
         return registrations[0] if registrations else None
 
+    async def get_profile_for_reuse(self, user_id: int) -> Optional[Dict]:
+        """Profile fields for re-registration: active reg first, else newest deleted.
+
+        Soft-deleted rows (e.g. «too expensive») keep full_name / year / letter so
+        the user does not retype the form.
+        """
+        active = await self.get_user_registration(user_id)
+        if active and active.get("full_name"):
+            return active
+        cursor = self.deleted_users.find({"user_id": user_id}).sort("_id", -1)
+        deleted = await cursor.to_list(length=1)
+        return deleted[0] if deleted else None
+
     async def delete_user_registration(
         self,
         user_id: int,

--- a/src/app.py
+++ b/src/app.py
@@ -80,6 +80,9 @@ class AppSettings(BaseSettings):
     payment_name: str
     # Personal /donate pay links. Prod default; override on Coolify dev if needed.
     payment_site_base_url: str = "https://146.school"
+    # Vision model for receipt amount + Maria-vs-site detection (litellm id).
+    # Sonnet preferred — Haiku misclassified receipts in practice.
+    payment_parse_model: str = "anthropic/claude-sonnet-4-6"
 
     delay_messages: bool = True
 
@@ -336,14 +339,11 @@ class App:
                     regular_amount = base + rate * (ref_years // step)
                 formula_amount = regular_amount
 
-            # Early bird discount
-            early_bird_discount = event.get("early_bird_discount", 0)
-            early_bird_deadline = event.get("early_bird_deadline")
-            if (
-                early_bird_deadline
-                and datetime.now().date() <= early_bird_deadline.date()
-                and early_bird_discount > 0
-            ):
+            # Early bird = same cutoff as food planning (D-4 06:00)
+            from src.payment_timeline import is_early_bird_active
+
+            early_bird_discount = int(event.get("early_bird_discount") or 0)
+            if early_bird_discount > 0 and is_early_bird_active(event):
                 discount = early_bird_discount
                 discounted_amount = max(0, regular_amount - discount)
             else:
@@ -366,14 +366,10 @@ class App:
         minimum = event.get("guest_price_minimum", 0)
         regular_price = max(minimum, registrant_price)
 
-        # Apply early bird discount to guest price
-        early_bird_discount = event.get("early_bird_discount", 0)
-        early_bird_deadline = event.get("early_bird_deadline")
-        if (
-            early_bird_deadline
-            and datetime.now().date() <= early_bird_deadline.date()
-            and early_bird_discount > 0
-        ):
+        from src.payment_timeline import is_early_bird_active
+
+        early_bird_discount = int(event.get("early_bird_discount") or 0)
+        if early_bird_discount > 0 and is_early_bird_active(event):
             discounted_price = max(0, regular_price - early_bird_discount)
         else:
             discounted_price = regular_price
@@ -868,6 +864,8 @@ class App:
         formula_amount: Optional[int] = None,
         username: Optional[str] = None,
         payment_status: Optional[str] = None,
+        payment_method: Optional[str] = None,
+        payment_method_source: Optional[str] = None,
     ):
         """
         Save payment information for a user
@@ -881,6 +879,8 @@ class App:
             formula_amount: The payment amount calculated by formula
             username: Optional user's Telegram username for logging
             payment_status: Payment status (pending, confirmed, None for just registered)
+            payment_method: ``on_site`` | ``to_maria`` when known
+            payment_method_source: ``user`` | ``ai`` | etc.
         """
         # Update the user's registration with payment info
         update_data = {
@@ -894,6 +894,10 @@ class App:
         # Add formula amount if provided
         if formula_amount is not None:
             update_data["formula_payment_amount"] = formula_amount
+        if payment_method is not None:
+            update_data["payment_method"] = payment_method
+        if payment_method_source is not None:
+            update_data["payment_method_source"] = payment_method_source
 
         # Get user registration for logging
         user_data = await self.collection.find_one(
@@ -912,6 +916,10 @@ class App:
         }
         if formula_amount is not None:
             log_data["formula_amount"] = formula_amount
+        if payment_method is not None:
+            log_data["payment_method"] = payment_method
+        if payment_method_source is not None:
+            log_data["payment_method_source"] = payment_method_source
 
         await self.save_event_log("payment_info", log_data, user_id, username)
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -46,8 +46,16 @@ def main(debug=False) -> None:
     bm = BotManager(bot=bot)
     bm.settings.ask_user.enabled = False
 
-    # Run database fix on startup
-    dp.startup.register(app.startup)
+    async def on_startup() -> None:
+        await app.startup()
+        try:
+            from src.reminder_scheduler import start_reminder_scheduler
+
+            start_reminder_scheduler(app, bot)
+        except Exception:
+            logger.exception("Failed to start payment reminder scheduler")
+
+    dp.startup.register(on_startup)
 
     # Setup dispatcher with our components
     bm.setup_dispatcher(dp)

--- a/src/export.py
+++ b/src/export.py
@@ -228,88 +228,69 @@ class SheetExporter:
         all_events = await self.app.get_all_events()
         return _build_events_map(all_events)
 
-    async def export_registered_users(
-        self, silent=False, event_id: Optional[str] = None
-    ):
-        """Export registered users to Google Sheets."""
-        query = {"event_id": event_id} if event_id else {}
-        cursor = self.app.collection.find(query)
-        users = await cursor.to_list(length=None)
+    def _ensure_worksheet(self, spreadsheet, titles: list, title: str):
+        """Return worksheet, creating it if missing; mutates *titles*."""
+        if title not in titles:
+            spreadsheet.add_worksheet(title=title, rows=1000, cols=20)
+            titles.append(title)
+        return spreadsheet.worksheet(title)
 
-        if not users:
-            logger.info("Нет пользователей для экспорта")
-            if not silent:
-                return "Нет пользователей для экспорта"
-            return None
-
-        events_map = await self._prefetch_events_map()
-
-        # Connect to Google Sheets
-        client = self._get_client()
-        spreadsheet = client.open_by_key(self.spreadsheet_id)
-        worksheet_titles = [ws.title for ws in spreadsheet.worksheets()]
-
-        # Main sheet
-        if "Все встречи" not in worksheet_titles:
-            spreadsheet.add_worksheet(title="Все встречи", rows=1000, cols=20)
-        main_sheet = spreadsheet.worksheet("Все встречи")
+    def _prepare_registered_export_sheets(self, spreadsheet, events_map: Dict):
+        """Create/clear main, per-event, and graduate-type worksheets."""
+        titles = [ws.title for ws in spreadsheet.worksheets()]
+        main_sheet = self._ensure_worksheet(spreadsheet, titles, "Все встречи")
         main_sheet.clear()
 
-        # Dynamic event-specific sheets (replace hardcoded cities)
         event_sheets = {}
         for eid, ev in events_map.items():
-            tab_name = ev.get("name", ev.get("city", eid))[
-                :100
-            ]  # Sheets tab name limit
-            if tab_name not in worksheet_titles:
-                spreadsheet.add_worksheet(title=tab_name, rows=1000, cols=20)
-                worksheet_titles.append(tab_name)
-            event_sheets[eid] = spreadsheet.worksheet(tab_name)
-            event_sheets[eid].clear()
+            tab_name = ev.get("name", ev.get("city", eid))[:100]
+            sheet = self._ensure_worksheet(spreadsheet, titles, tab_name)
+            sheet.clear()
+            event_sheets[eid] = sheet
 
-        # Graduate type sheets
         type_sheets = {}
-        for graduate_type in ["Выпускники", "Учителя", "Друзья", "Организаторы"]:
-            if graduate_type not in worksheet_titles:
-                spreadsheet.add_worksheet(title=graduate_type, rows=1000, cols=20)
-            type_sheets[graduate_type] = spreadsheet.worksheet(graduate_type)
-            type_sheets[graduate_type].clear()
+        for graduate_type in ("Выпускники", "Учителя", "Друзья", "Организаторы"):
+            sheet = self._ensure_worksheet(spreadsheet, titles, graduate_type)
+            sheet.clear()
+            type_sheets[graduate_type] = sheet
 
-        # Update all sheets with headers
         main_sheet.update([REGISTERED_HEADERS])
         for sheet in event_sheets.values():
             sheet.update([REGISTERED_HEADERS])
         for sheet in type_sheets.values():
             sheet.update([REGISTERED_HEADERS])
+        return main_sheet, event_sheets, type_sheets
 
-        # Build rows
+    @staticmethod
+    def _type_sheet_key(graduate_type: str) -> Optional[str]:
+        display = GRADUATE_TYPE_MAP.get(graduate_type, "Выпускник")
+        return {
+            "Выпускник": "Выпускники",
+            "Учитель": "Учителя",
+            "Друг": "Друзья",
+            "Организатор": "Организаторы",
+        }.get(display)
+
+    def _bucket_registered_rows(self, users, events_map, event_sheets, type_sheets):
         main_rows = []
         event_rows = {eid: [] for eid in event_sheets}
         type_rows = {gt: [] for gt in type_sheets}
-
         for user in users:
             event = events_map.get(user.get("event_id", ""))
             row = _build_registered_row(user, event)
             main_rows.append(row)
-
-            # Route to event sheet
             uid_event = user.get("event_id", "")
             if uid_event in event_rows:
                 event_rows[uid_event].append(row)
+            key = self._type_sheet_key(user.get("graduate_type", "GRADUATE"))
+            if key and key in type_rows:
+                type_rows[key].append(row)
+        return main_rows, event_rows, type_rows
 
-            # Route to type sheet
-            graduate_type = user.get("graduate_type", "GRADUATE")
-            graduate_type_display = GRADUATE_TYPE_MAP.get(graduate_type, "Выпускник")
-            if graduate_type_display == "Выпускник":
-                type_rows["Выпускники"].append(row)
-            elif graduate_type_display == "Учитель":
-                type_rows["Учителя"].append(row)
-            elif graduate_type_display == "Друг":
-                type_rows["Друзья"].append(row)
-            elif graduate_type_display == "Организатор":
-                type_rows["Организаторы"].append(row)
-
-        # Write data
+    @staticmethod
+    def _write_row_buckets(
+        main_sheet, main_rows, event_sheets, event_rows, type_sheets, type_rows
+    ):
         if main_rows:
             main_sheet.update(main_rows, "A2")
         for eid, rows in event_rows.items():
@@ -319,15 +300,35 @@ class SheetExporter:
             if rows:
                 type_sheets[gt].update(rows, "A2")
 
+    async def export_registered_users(
+        self, silent=False, event_id: Optional[str] = None
+    ):
+        """Export registered users to Google Sheets."""
+        query = {"event_id": event_id} if event_id else {}
+        users = await self.app.collection.find(query).to_list(length=None)
+
+        if not users:
+            logger.info("Нет пользователей для экспорта")
+            return None if silent else "Нет пользователей для экспорта"
+
+        events_map = await self._prefetch_events_map()
+        spreadsheet = self._get_client().open_by_key(self.spreadsheet_id)
+        main_sheet, event_sheets, type_sheets = self._prepare_registered_export_sheets(
+            spreadsheet, events_map
+        )
+        main_rows, event_rows, type_rows = self._bucket_registered_rows(
+            users, events_map, event_sheets, type_sheets
+        )
+        self._write_row_buckets(
+            main_sheet, main_rows, event_sheets, event_rows, type_sheets, type_rows
+        )
+
         message = (
             f"Успешно экспортировано {len(main_rows)} пользователей в Google Таблицы\n"
+            f"Доступно по ссылке: {main_sheet.url}"
         )
-        message += "Доступно по ссылке: " + main_sheet.url
         logger.success(message)
-
-        if not silent:
-            return message
-        return None
+        return None if silent else message
 
     async def export_to_csv(self, event_id: Optional[str] = None):
         """Export registered users to a CSV file."""

--- a/src/payment_reminders.py
+++ b/src/payment_reminders.py
@@ -1,16 +1,121 @@
-"""Send D-4 / D-2 payment reminders to unpaid registrants."""
+"""Payment reminders: auto schedule, admin preview (D-1), pause / send now.
+
+Control state lives in Mongo collection ``payment_reminder_controls``
+(one doc per event_id + kind). Per-user send flags stay on registrations.
+"""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Optional
 
 from loguru import logger
 
-from src.payment_timeline import reminder_kind_for_event, reminder_message
+from src.payment_timeline import (
+    admin_preview_kinds_for_event,
+    kind_label_ru,
+    reminder_kind_for_event,
+    reminder_message,
+)
+
+CONTROL_COLLECTION = "payment_reminder_controls"
+KIND_FLAG = {
+    "d4": "payment_reminder_d4_sent",
+    "d2": "payment_reminder_d2_sent",
+}
+
+
+def _event_id(event: dict) -> str:
+    return str(event["_id"])
+
+
+def _control_id(event_id: str, kind: str) -> str:
+    return f"{event_id}:{kind}"
+
+
+def _get_database():
+    from botspot import get_database
+
+    return get_database()
+
+
+async def controls_collection(app):
+    if getattr(app, "_reminder_controls", None) is None:
+        app._reminder_controls = _get_database().get_collection(CONTROL_COLLECTION)
+    return app._reminder_controls
+
+
+async def get_control(app, event_id: str, kind: str) -> dict:
+    col = await controls_collection(app)
+    doc = await col.find_one({"_id": _control_id(event_id, kind)})
+    if doc:
+        return doc
+    return {
+        "_id": _control_id(event_id, kind),
+        "event_id": event_id,
+        "kind": kind,
+        "paused": False,
+        "admin_preview_sent": False,
+        "admin_preview_sent_at": None,
+        "auto_send_completed": False,
+        "auto_send_completed_at": None,
+    }
+
+
+async def set_paused(app, event_id: str, kind: str, paused: bool) -> dict:
+    col = await controls_collection(app)
+    now = datetime.now().isoformat()
+    await col.update_one(
+        {"_id": _control_id(event_id, kind)},
+        {
+            "$set": {
+                "event_id": event_id,
+                "kind": kind,
+                "paused": paused,
+                "paused_updated_at": now,
+            },
+            "$setOnInsert": {"admin_preview_sent": False, "auto_send_completed": False},
+        },
+        upsert=True,
+    )
+    return await get_control(app, event_id, kind)
+
+
+async def mark_admin_preview_sent(app, event_id: str, kind: str) -> None:
+    col = await controls_collection(app)
+    await col.update_one(
+        {"_id": _control_id(event_id, kind)},
+        {
+            "$set": {
+                "event_id": event_id,
+                "kind": kind,
+                "admin_preview_sent": True,
+                "admin_preview_sent_at": datetime.now().isoformat(),
+            },
+            "$setOnInsert": {"paused": False, "auto_send_completed": False},
+        },
+        upsert=True,
+    )
+
+
+async def mark_auto_send_completed(app, event_id: str, kind: str) -> None:
+    col = await controls_collection(app)
+    await col.update_one(
+        {"_id": _control_id(event_id, kind)},
+        {
+            "$set": {
+                "event_id": event_id,
+                "kind": kind,
+                "auto_send_completed": True,
+                "auto_send_completed_at": datetime.now().isoformat(),
+            },
+            "$setOnInsert": {"paused": False, "admin_preview_sent": False},
+        },
+        upsert=True,
+    )
 
 
 async def iter_unpaid_for_reminders(app, event: dict) -> list[dict]:
-    event_id = str(event["_id"])
+    event_id = _event_id(event)
     cursor = app.collection.find(
         {
             "event_id": event_id,
@@ -20,64 +125,248 @@ async def iter_unpaid_for_reminders(app, event: dict) -> list[dict]:
     return await cursor.to_list(length=None)
 
 
+def _eligible_events(events: list[dict]) -> list[dict]:
+    out = []
+    for event in events:
+        status = event.get("status")
+        if status in ("archived", "passed"):
+            continue
+        if status in ("upcoming", "registration_closed", None) or event.get(
+            "enabled", True
+        ):
+            out.append(event)
+    return out
+
+
+async def build_reminder_batch(
+    app, event: dict, kind: str
+) -> tuple[list[dict], str]:
+    """Return (unpaid regs not yet messaged, message text)."""
+    city = event.get("city", "городе")
+    text = reminder_message(kind, event, city)
+    flag = KIND_FLAG[kind]
+    unpaid = await iter_unpaid_for_reminders(app, event)
+    targets = []
+    for reg in unpaid:
+        if reg.get(flag):
+            continue
+        if not reg.get("user_id"):
+            continue
+        targets.append(reg)
+    return targets, text
+
+
+def format_admin_preview(
+    event: dict,
+    kind: str,
+    targets: list[dict],
+    text: str,
+    *,
+    paused: bool,
+    send_date_display: str,
+) -> str:
+    city = event.get("city", "?")
+    label = kind_label_ru(kind)
+    names = []
+    for reg in targets[:40]:
+        uname = f"@{reg['username']}" if reg.get("username") else "—"
+        names.append(f"• {reg.get('full_name', '?')} ({uname})")
+    more = ""
+    if len(targets) > 40:
+        more = f"\n… и ещё {len(targets) - 40}"
+    pause_line = (
+        "⏸ <b>ПАУЗА</b> — авто-отправка не пойдёт, пока не снимете.\n"
+        if paused
+        else ""
+    )
+    return (
+        f"📋 <b>Завтра авто-напоминание</b> {label}\n"
+        f"Встреча: {city} · event {_event_id(event)[:8]}…\n"
+        f"Дата отправки пользователям: <b>{send_date_display}</b>\n"
+        f"{pause_line}"
+        f"Получателей (неоплатившие, ещё не слали): <b>{len(targets)}</b>\n"
+        f"{chr(10).join(names)}{more}\n\n"
+        f"——— полный текст ——-\n{text}\n\n"
+        "Админ → Управление → Напоминания об оплате: "
+        "пауза / снять паузу / отправить сейчас."
+    )
+
+
 async def send_payment_reminders(
     app,
     bot,
     *,
     now: Optional[datetime] = None,
     dry_run: bool = False,
+    force_kind: Optional[str] = None,
+    force_event_id: Optional[str] = None,
+    respect_pause: bool = True,
+    only_due_today: bool = True,
 ) -> dict[str, Any]:
-    """Scan upcoming events; send at most one D-4 and one D-2 per registration.
+    """Send D-4 / D-2 payment reminders.
 
-    Marks ``payment_reminder_d4_sent`` / ``payment_reminder_d2_sent`` on the reg.
+    *force_event_id* + *force_kind*: admin «send now» (ignores calendar day).
+    *only_due_today*: when True, only kinds due on *now*'s date (unless force).
     """
     now = now or datetime.now()
-    stats = {"events": 0, "d4": 0, "d2": 0, "errors": 0, "skipped": 0}
+    stats: dict[str, Any] = {
+        "events": 0,
+        "d4": 0,
+        "d2": 0,
+        "errors": 0,
+        "skipped": 0,
+        "paused": 0,
+    }
 
-    events = await app.get_all_events()
+    events = _eligible_events(await app.get_all_events())
     for event in events:
-        status = event.get("status")
-        if status in ("archived", "passed"):
-            continue
-        if not event.get("enabled", True) and status != "upcoming":
-            # still allow registration_closed if people need to pay
-            if status not in ("upcoming", "registration_closed"):
-                continue
-
-        kind = reminder_kind_for_event(event, now)
-        if not kind:
+        eid = _event_id(event)
+        if force_event_id and eid != force_event_id:
             continue
 
-        stats["events"] += 1
-        city = event.get("city", "городе")
-        text = reminder_message(kind, event, city)
-        flag = (
-            "payment_reminder_d4_sent" if kind == "d4" else "payment_reminder_d2_sent"
-        )
+        if force_kind:
+            kinds = [force_kind]
+        elif only_due_today:
+            k = reminder_kind_for_event(event, now)
+            kinds = [k] if k else []
+        else:
+            kinds = []
 
-        unpaid = await iter_unpaid_for_reminders(app, event)
-        for reg in unpaid:
-            if reg.get(flag):
+        for kind in kinds:
+            if respect_pause:
+                ctrl = await get_control(app, eid, kind)
+                if ctrl.get("paused"):
+                    stats["paused"] += 1
+                    logger.info(f"reminder {kind} paused for event {eid}")
+                    continue
+
+            stats["events"] += 1
+            targets, text = await build_reminder_batch(app, event, kind)
+            flag = KIND_FLAG[kind]
+            if not targets:
                 stats["skipped"] += 1
                 continue
-            user_id = reg.get("user_id")
-            if not user_id:
-                stats["skipped"] += 1
-                continue
-            if dry_run:
-                stats[kind] += 1
-                continue
-            try:
-                await bot.send_message(int(user_id), text)
-                await app.collection.update_one(
-                    {"_id": reg["_id"]},
-                    {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
-                )
-                stats[kind] += 1
-            except Exception as e:
-                stats["errors"] += 1
-                logger.warning(
-                    f"payment reminder {kind} failed for user {user_id}: {e}"
-                )
+
+            for reg in targets:
+                user_id = reg.get("user_id")
+                if dry_run:
+                    stats[kind] += 1
+                    continue
+                try:
+                    await bot.send_message(int(user_id), text)
+                    await app.collection.update_one(
+                        {"_id": reg["_id"]},
+                        {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
+                    )
+                    stats[kind] += 1
+                except Exception as e:
+                    stats["errors"] += 1
+                    logger.warning(
+                        f"payment reminder {kind} failed for user {user_id}: {e}"
+                    )
+
+            if not dry_run and not force_kind:
+                await mark_auto_send_completed(app, eid, kind)
 
     return stats
+
+
+async def send_admin_previews(
+    app,
+    *,
+    now: Optional[datetime] = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Day before each reminder: summary + full text to events/logs chat."""
+    now = now or datetime.now()
+    stats = {"previews": 0, "skipped": 0, "errors": 0}
+    events = _eligible_events(await app.get_all_events())
+
+    for event in events:
+        eid = _event_id(event)
+        for kind in admin_preview_kinds_for_event(event, now):
+            ctrl = await get_control(app, eid, kind)
+            if ctrl.get("admin_preview_sent"):
+                stats["skipped"] += 1
+                continue
+            targets, text = await build_reminder_batch(app, event, kind)
+            send_date = (now.date() + timedelta(days=1)).strftime("%d.%m.%Y")
+            body = format_admin_preview(
+                event,
+                kind,
+                targets,
+                text,
+                paused=bool(ctrl.get("paused")),
+                send_date_display=send_date,
+            )
+            if dry_run:
+                stats["previews"] += 1
+                continue
+            try:
+                sent = await app.log_to_chat(body, "events")
+                if sent is None:
+                    sent = await app.log_to_chat(body, "logs")
+                if sent is None:
+                    logger.warning(
+                        "admin reminder preview: no events/logs chat configured"
+                    )
+                    stats["errors"] += 1
+                    continue
+                await mark_admin_preview_sent(app, eid, kind)
+                stats["previews"] += 1
+            except Exception as e:
+                stats["errors"] += 1
+                logger.warning(f"admin preview failed event={eid} kind={kind}: {e}")
+
+    return stats
+
+
+async def list_upcoming_reminder_plan(
+    app, *, now: Optional[datetime] = None, days_ahead: int = 14
+) -> list[dict]:
+    """Plan rows for admin UI: next N days of previews + sends."""
+    from src.payment_timeline import badge_deadline, food_deadline
+
+    now = now or datetime.now()
+    plan = []
+    events = _eligible_events(await app.get_all_events())
+    for event in events:
+        eid = _event_id(event)
+        for kind, dl_fn in (("d4", food_deadline), ("d2", badge_deadline)):
+            dl = dl_fn(event)
+            if not dl:
+                continue
+            send_day = dl.date()
+            preview_day = send_day - timedelta(days=1)
+            if send_day < now.date() or send_day > now.date() + timedelta(
+                days=days_ahead
+            ):
+                continue
+            ctrl = await get_control(app, eid, kind)
+            targets, text = await build_reminder_batch(app, event, kind)
+            plan.append(
+                {
+                    "event_id": eid,
+                    "city": event.get("city", "?"),
+                    "kind": kind,
+                    "label": kind_label_ru(kind),
+                    "preview_day": preview_day.isoformat(),
+                    "send_day": send_day.isoformat(),
+                    "paused": bool(ctrl.get("paused")),
+                    "recipient_count": len(targets),
+                    "text": text,
+                }
+            )
+    plan.sort(key=lambda r: (r["send_day"], r["kind"]))
+    return plan
+
+
+async def daily_reminder_tick(app, bot, *, now: Optional[datetime] = None) -> dict:
+    """Scheduled job: admin previews for tomorrow + user sends due today."""
+    now = now or datetime.now()
+    preview_stats = await send_admin_previews(app, now=now, dry_run=False)
+    send_stats = await send_payment_reminders(
+        app, bot, now=now, dry_run=False, only_due_today=True, respect_pause=True
+    )
+    logger.info(f"payment reminder tick: previews={preview_stats} sends={send_stats}")
+    return {"preview": preview_stats, "send": send_stats}

--- a/src/payment_reminders.py
+++ b/src/payment_reminders.py
@@ -3,6 +3,7 @@
 Control state lives in Mongo collection ``payment_reminder_controls``
 (one doc per event_id + kind). Per-user send flags stay on registrations.
 """
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -138,9 +139,7 @@ def _eligible_events(events: list[dict]) -> list[dict]:
     return out
 
 
-async def build_reminder_batch(
-    app, event: dict, kind: str
-) -> tuple[list[dict], str]:
+async def build_reminder_batch(app, event: dict, kind: str) -> tuple[list[dict], str]:
     """Return (unpaid regs not yet messaged, message text)."""
     city = event.get("city", "городе")
     text = reminder_message(kind, event, city)
@@ -175,9 +174,7 @@ def format_admin_preview(
     if len(targets) > 40:
         more = f"\n… и ещё {len(targets) - 40}"
     pause_line = (
-        "⏸ <b>ПАУЗА</b> — авто-отправка не пойдёт, пока не снимете.\n"
-        if paused
-        else ""
+        "⏸ <b>ПАУЗА</b> — авто-отправка не пойдёт, пока не снимете.\n" if paused else ""
     )
     return (
         f"📋 <b>Завтра авто-напоминание</b> {label}\n"
@@ -190,6 +187,90 @@ def format_admin_preview(
         "Админ → Управление → Напоминания об оплате: "
         "пауза / снять паузу / отправить сейчас."
     )
+
+
+def _kinds_for_event(
+    event: dict,
+    *,
+    now: datetime,
+    force_kind: Optional[str],
+    only_due_today: bool,
+) -> list[str]:
+    if force_kind:
+        return [force_kind]
+    if only_due_today:
+        k = reminder_kind_for_event(event, now)
+        return [k] if k else []
+    return []
+
+
+async def _deliver_batch(
+    app,
+    bot,
+    *,
+    targets: list[dict],
+    text: str,
+    kind: str,
+    now: datetime,
+    dry_run: bool,
+    stats: dict[str, Any],
+) -> None:
+    flag = KIND_FLAG[kind]
+    for reg in targets:
+        user_id = reg.get("user_id")
+        if dry_run:
+            stats[kind] += 1
+            continue
+        try:
+            await bot.send_message(int(user_id), text)
+            await app.collection.update_one(
+                {"_id": reg["_id"]},
+                {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
+            )
+            stats[kind] += 1
+        except Exception as e:
+            stats["errors"] += 1
+            logger.warning(f"payment reminder {kind} failed for user {user_id}: {e}")
+
+
+async def _send_kind_for_event(
+    app,
+    bot,
+    event: dict,
+    kind: str,
+    *,
+    now: datetime,
+    dry_run: bool,
+    respect_pause: bool,
+    force_kind: Optional[str],
+    stats: dict[str, Any],
+) -> None:
+    eid = _event_id(event)
+    if respect_pause:
+        ctrl = await get_control(app, eid, kind)
+        if ctrl.get("paused"):
+            stats["paused"] += 1
+            logger.info(f"reminder {kind} paused for event {eid}")
+            return
+
+    stats["events"] += 1
+    targets, text = await build_reminder_batch(app, event, kind)
+    if not targets:
+        stats["skipped"] += 1
+        return
+
+    await _deliver_batch(
+        app,
+        bot,
+        targets=targets,
+        text=text,
+        kind=kind,
+        now=now,
+        dry_run=dry_run,
+        stats=stats,
+    )
+    if not dry_run and not force_kind:
+        await mark_auto_send_completed(app, eid, kind)
 
 
 async def send_payment_reminders(
@@ -218,55 +299,24 @@ async def send_payment_reminders(
         "paused": 0,
     }
 
-    events = _eligible_events(await app.get_all_events())
-    for event in events:
+    for event in _eligible_events(await app.get_all_events()):
         eid = _event_id(event)
         if force_event_id and eid != force_event_id:
             continue
-
-        if force_kind:
-            kinds = [force_kind]
-        elif only_due_today:
-            k = reminder_kind_for_event(event, now)
-            kinds = [k] if k else []
-        else:
-            kinds = []
-
-        for kind in kinds:
-            if respect_pause:
-                ctrl = await get_control(app, eid, kind)
-                if ctrl.get("paused"):
-                    stats["paused"] += 1
-                    logger.info(f"reminder {kind} paused for event {eid}")
-                    continue
-
-            stats["events"] += 1
-            targets, text = await build_reminder_batch(app, event, kind)
-            flag = KIND_FLAG[kind]
-            if not targets:
-                stats["skipped"] += 1
-                continue
-
-            for reg in targets:
-                user_id = reg.get("user_id")
-                if dry_run:
-                    stats[kind] += 1
-                    continue
-                try:
-                    await bot.send_message(int(user_id), text)
-                    await app.collection.update_one(
-                        {"_id": reg["_id"]},
-                        {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
-                    )
-                    stats[kind] += 1
-                except Exception as e:
-                    stats["errors"] += 1
-                    logger.warning(
-                        f"payment reminder {kind} failed for user {user_id}: {e}"
-                    )
-
-            if not dry_run and not force_kind:
-                await mark_auto_send_completed(app, eid, kind)
+        for kind in _kinds_for_event(
+            event, now=now, force_kind=force_kind, only_due_today=only_due_today
+        ):
+            await _send_kind_for_event(
+                app,
+                bot,
+                event,
+                kind,
+                now=now,
+                dry_run=dry_run,
+                respect_pause=respect_pause,
+                force_kind=force_kind,
+                stats=stats,
+            )
 
     return stats
 

--- a/src/payment_reminders.py
+++ b/src/payment_reminders.py
@@ -1,0 +1,83 @@
+"""Send D-4 / D-2 payment reminders to unpaid registrants."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from loguru import logger
+
+from src.payment_timeline import reminder_kind_for_event, reminder_message
+
+
+async def iter_unpaid_for_reminders(app, event: dict) -> list[dict]:
+    event_id = str(event["_id"])
+    cursor = app.collection.find(
+        {
+            "event_id": event_id,
+            "payment_status": {"$nin": ["confirmed", "pending"]},
+        }
+    )
+    return await cursor.to_list(length=None)
+
+
+async def send_payment_reminders(
+    app,
+    bot,
+    *,
+    now: Optional[datetime] = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Scan upcoming events; send at most one D-4 and one D-2 per registration.
+
+    Marks ``payment_reminder_d4_sent`` / ``payment_reminder_d2_sent`` on the reg.
+    """
+    now = now or datetime.now()
+    stats = {"events": 0, "d4": 0, "d2": 0, "errors": 0, "skipped": 0}
+
+    events = await app.get_all_events()
+    for event in events:
+        status = event.get("status")
+        if status in ("archived", "passed"):
+            continue
+        if not event.get("enabled", True) and status != "upcoming":
+            # still allow registration_closed if people need to pay
+            if status not in ("upcoming", "registration_closed"):
+                continue
+
+        kind = reminder_kind_for_event(event, now)
+        if not kind:
+            continue
+
+        stats["events"] += 1
+        city = event.get("city", "городе")
+        text = reminder_message(kind, event, city)
+        flag = (
+            "payment_reminder_d4_sent" if kind == "d4" else "payment_reminder_d2_sent"
+        )
+
+        unpaid = await iter_unpaid_for_reminders(app, event)
+        for reg in unpaid:
+            if reg.get(flag):
+                stats["skipped"] += 1
+                continue
+            user_id = reg.get("user_id")
+            if not user_id:
+                stats["skipped"] += 1
+                continue
+            if dry_run:
+                stats[kind] += 1
+                continue
+            try:
+                await bot.send_message(int(user_id), text)
+                await app.collection.update_one(
+                    {"_id": reg["_id"]},
+                    {"$set": {flag: True, f"{flag}_at": now.isoformat()}},
+                )
+                stats[kind] += 1
+            except Exception as e:
+                stats["errors"] += 1
+                logger.warning(
+                    f"payment reminder {kind} failed for user {user_id}: {e}"
+                )
+
+    return stats

--- a/src/payment_timeline.py
+++ b/src/payment_timeline.py
@@ -1,0 +1,159 @@
+"""Meetup payment timeline: food planning (D-4) and named badge (D-2).
+
+Deadlines are at 06:00 on the calendar day N days before the event date
+(buffer: “before six in the morning”). Timezone-naive datetimes are treated
+as local wall time of the stored event date.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from typing import Any, Optional
+
+
+FOOD_DAYS_BEFORE = 4
+BADGE_DAYS_BEFORE = 2
+DEADLINE_HOUR = 6  # 06:00
+
+
+def _as_date(value: Any) -> Optional[date]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+        except ValueError:
+            return None
+    return None
+
+
+def event_date(event: dict) -> Optional[date]:
+    return _as_date(event.get("date"))
+
+
+def deadline_at(event: dict, days_before: int, hour: int = DEADLINE_HOUR) -> Optional[datetime]:
+    """Instant after which the “late” rule applies (06:00 on that morning)."""
+    d = event_date(event)
+    if d is None:
+        return None
+    day = d - timedelta(days=days_before)
+    return datetime.combine(day, time(hour=hour, minute=0, second=0))
+
+
+def food_deadline(event: dict) -> Optional[datetime]:
+    return deadline_at(event, FOOD_DAYS_BEFORE)
+
+
+def badge_deadline(event: dict) -> Optional[datetime]:
+    return deadline_at(event, BADGE_DAYS_BEFORE)
+
+
+def format_deadline_ru(dt: Optional[datetime]) -> str:
+    if dt is None:
+        return "—"
+    return dt.strftime("%d.%m.%Y в %H:%M")
+
+
+@dataclass(frozen=True)
+class TimelineCopy:
+    food_deadline: Optional[datetime]
+    badge_deadline: Optional[datetime]
+    food_deadline_display: str
+    badge_deadline_display: str
+    after_food_deadline: bool
+    after_badge_deadline: bool
+
+
+def timeline_for(event: dict, now: Optional[datetime] = None) -> TimelineCopy:
+    now = now or datetime.now()
+    food = food_deadline(event)
+    badge = badge_deadline(event)
+    return TimelineCopy(
+        food_deadline=food,
+        badge_deadline=badge,
+        food_deadline_display=format_deadline_ru(food),
+        badge_deadline_display=format_deadline_ru(badge),
+        after_food_deadline=bool(food and now >= food),
+        after_badge_deadline=bool(badge and now >= badge),
+    )
+
+
+def pay_later_message(event: dict, now: Optional[datetime] = None) -> str:
+    """User-facing text after «Оплачу позже»."""
+    t = timeline_for(event, now)
+    return (
+        "Хорошо! Вы можете оплатить позже — команда /pay "
+        "(там же ссылка на сайт и реквизиты).\n\n"
+        "⏱ Сроки (ориентир — 06:00):\n"
+        f"• до <b>{t.food_deadline_display}</b> — успеваете в общий заказ еды;\n"
+        f"• после этой даты — пожалуйста, <b>принесите немного еды с собой</b>: "
+        "мы заказываем заранее, и при большом числе поздних оплат на месте "
+        "может не хватить / придётся докупать.\n"
+        f"• до <b>{t.badge_deadline_display}</b> — успеваем подготовить "
+        "<b>именной бейдж</b>;\n"
+        "• позже — бейдж уже не печатаем (вас всё равно ждут).\n\n"
+        "После оплаты пришлите скриншот в этот чат (или нажмите «Оплатил» в /pay)."
+    )
+
+
+def reminder_kind_for_event(
+    event: dict, now: Optional[datetime] = None
+) -> Optional[str]:
+    """Return ``d4`` or ``d2`` if *now* falls on that reminder calendar day.
+
+    Reminder day = calendar day of the corresponding 06:00 deadline
+    (D-4 food planning day, D-2 badge day).
+    """
+    now = now or datetime.now()
+    food = food_deadline(event)
+    badge = badge_deadline(event)
+    today = now.date()
+    if food and today == food.date():
+        return "d4"
+    if badge and today == badge.date():
+        return "d2"
+    return None
+
+
+def reminder_message(kind: str, event: dict, city: str) -> str:
+    t = timeline_for(event)
+    if kind == "d4":
+        return (
+            f"Напоминание о встрече в {city}: до мероприятия 4 дня.\n\n"
+            f"Если ещё не оплатили взнос — сейчас удобное время (/pay).\n"
+            f"После <b>{t.food_deadline_display}</b> еду планируем с запасом; "
+            "при поздней оплате лучше принести что-то к столу с собой.\n"
+            f"Именной бейдж — если оплатите до <b>{t.badge_deadline_display}</b>."
+        )
+    if kind == "d2":
+        return (
+            f"Напоминание о встрече в {city}: осталось 2 дня.\n\n"
+            f"<b>Последний срок для именного бейджа</b> — "
+            f"<b>{t.badge_deadline_display}</b>.\n"
+            "Оплатить: /pay. После оплаты пришлите скриншот в чат."
+        )
+    raise ValueError(f"unknown reminder kind: {kind}")
+
+
+VOLUNTEER_OPTIONS_TEXT = (
+    "Если хотите помочь вместо взноса или в дополнение — напишите "
+    "организатору <b>@mariikors</b>. Мария решает индивидуально "
+    "(скидка / бесплатный вход / волонтёрство).\n\n"
+    "Примеры задач:\n"
+    "• проверка бейджей на входе\n"
+    "• помощь с готовкой / уборкой / орг. делами\n"
+    "• фото, видео, stories\n"
+    "• активности, музыка, программа"
+)
+
+
+def too_expensive_cancel_message() -> str:
+    return (
+        "Понимаем. Регистрацию отменили.\n\n"
+        "Если передумаете — /start (данные подставим, если найдём прошлую анкету).\n\n"
+        f"{VOLUNTEER_OPTIONS_TEXT}"
+    )

--- a/src/payment_timeline.py
+++ b/src/payment_timeline.py
@@ -64,6 +64,75 @@ def format_deadline_ru(dt: Optional[datetime]) -> str:
     return dt.strftime("%d.%m.%Y в %H:%M")
 
 
+def format_date_short_ru(value: Any) -> str:
+    """Compact dd.mm for Telegram preview / TL;DR lines."""
+    if value is None:
+        return "—"
+    if isinstance(value, datetime):
+        return value.strftime("%d.%m")
+    if isinstance(value, date):
+        return value.strftime("%d.%m")
+    d = _as_date(value)
+    return d.strftime("%d.%m") if d else "—"
+
+
+def _as_datetime_date(value: Any) -> Optional[date]:
+    return _as_date(value)
+
+
+@dataclass(frozen=True)
+class EarlyBirdInfo:
+    discount: int
+    deadline: date
+    deadline_at: datetime
+    deadline_display: str  # full «dd.mm.YYYY в HH:MM» (same as food)
+    deadline_short: str  # dd.mm
+
+
+def early_bird_deadline_at(event: dict) -> Optional[datetime]:
+    """Early-bird cutoff = food planning cutoff (D-4 at 06:00).
+
+    Only when ``early_bird_discount > 0``. Stored ``early_bird_deadline`` is not
+    used for timing so pay-later / reminders / price math stay aligned.
+    """
+    if int(event.get("early_bird_discount") or 0) <= 0:
+        return None
+    return food_deadline(event)
+
+
+def is_early_bird_active(event: dict, now: Optional[datetime] = None) -> bool:
+    """True while now is strictly before the shared food / early-bird cutoff."""
+    now = now or datetime.now()
+    dl = early_bird_deadline_at(event)
+    return bool(dl and now < dl)
+
+
+def early_bird_info(event: dict) -> Optional[EarlyBirdInfo]:
+    """Return early-bird discount + shared cutoff if discount is configured."""
+    discount = int(event.get("early_bird_discount") or 0)
+    dl = early_bird_deadline_at(event)
+    if discount <= 0 or dl is None:
+        return None
+    return EarlyBirdInfo(
+        discount=discount,
+        deadline=dl.date(),
+        deadline_at=dl,
+        deadline_display=format_deadline_ru(dl),
+        deadline_short=format_date_short_ru(dl),
+    )
+
+
+def early_bird_near_food_cutoff(
+    event: dict, *, window_days: int = 2
+) -> Optional[EarlyBirdInfo]:
+    """Early bird for D-4 reminders: same cutoff as food (always 'near' when set).
+
+    ``window_days`` kept for call-site compatibility; unused after alignment.
+    """
+    _ = window_days
+    return early_bird_info(event)
+
+
 @dataclass(frozen=True)
 class TimelineCopy:
     food_deadline: Optional[datetime]
@@ -88,14 +157,31 @@ def timeline_for(event: dict, now: Optional[datetime] = None) -> TimelineCopy:
     )
 
 
+CANCEL_REGISTRATION_FOOTER = (
+    "Если передумали и не придёте — не забудьте отменить регистрацию: "
+    "/cancel_registration"
+)
+
+
 def pay_later_message(event: dict, now: Optional[datetime] = None) -> str:
     """User-facing text after «Оплачу позже»."""
+    now = now or datetime.now()
     t = timeline_for(event, now)
+    eb = early_bird_info(event)
+    if eb and not t.after_food_deadline:
+        food_line = (
+            f"• до <b>{t.food_deadline_display}</b> — успеваете в общий заказ еды "
+            f"и скидка за раннюю регистрацию (−{eb.discount}₽);\n"
+        )
+    else:
+        food_line = (
+            f"• до <b>{t.food_deadline_display}</b> — успеваете в общий заказ еды;\n"
+        )
     return (
         "Хорошо! Вы можете оплатить позже — команда /pay "
         "(там же ссылка на сайт и реквизиты).\n\n"
         "⏱ Сроки (ориентир — 06:00):\n"
-        f"• до <b>{t.food_deadline_display}</b> — успеваете в общий заказ еды;\n"
+        f"{food_line}"
         f"• после этой даты — пожалуйста, <b>принесите немного еды с собой</b>: "
         "мы заказываем заранее, и при большом числе поздних оплат на месте "
         "может не хватить / придётся докупать.\n"
@@ -150,21 +236,52 @@ def admin_preview_kinds_for_event(
 
 
 def reminder_message(kind: str, event: dict, city: str) -> str:
+    """Auto-reminder copy. First line is a dense TL;DR for Telegram chat preview."""
     t = timeline_for(event)
+    food_short = format_date_short_ru(t.food_deadline)
+    badge_short = format_date_short_ru(t.badge_deadline)
+    eb = early_bird_near_food_cutoff(event)
+
     if kind == "d4":
-        return (
-            f"Напоминание о встрече в {city}: до мероприятия 4 дня.\n\n"
-            f"Если ещё не оплатили взнос — сейчас удобное время (/pay).\n"
-            f"После <b>{t.food_deadline_display}</b> еду планируем с запасом; "
-            "при поздней оплате лучше принести что-то к столу с собой.\n"
-            f"Именной бейдж — если оплатите до <b>{t.badge_deadline_display}</b>."
+        # First line ≈ chat list preview (keep short, high-signal).
+        tldr_bits = [f"⏱ {city} · 4 дня", f"еда до {food_short}"]
+        if eb:
+            tldr_bits.append(f"ранняя −{eb.discount}₽ до {eb.deadline_short}")
+        tldr_bits.append("/pay")
+        tldr = " · ".join(tldr_bits)
+
+        body = (
+            f"{tldr}\n\n"
+            "Если ещё не оплатили взнос — сейчас удобный момент: /pay.\n"
         )
+        if eb:
+            body += (
+                f"До <b>{t.food_deadline_display}</b> — общий заказ еды "
+                f"и ранняя скидка <b>−{eb.discount}₽</b>; "
+                "после — еду планируем с запасом, при поздней оплате лучше "
+                "принести что-то к столу с собой.\n"
+            )
+        else:
+            body += (
+                f"После <b>{t.food_deadline_display}</b> еду планируем с запасом; "
+                "при поздней оплате лучше принести что-то к столу с собой.\n"
+            )
+        body += (
+            f"Именной бейдж — если оплатите до <b>{t.badge_deadline_display}</b>."
+            f"\n\n{CANCEL_REGISTRATION_FOOTER}"
+        )
+        return body
+
     if kind == "d2":
+        tldr = (
+            f"⏱ {city} · 2 дня · бейдж до {badge_short} · /pay"
+        )
         return (
-            f"Напоминание о встрече в {city}: осталось 2 дня.\n\n"
+            f"{tldr}\n\n"
             f"<b>Последний срок для именного бейджа</b> — "
             f"<b>{t.badge_deadline_display}</b>.\n"
-            "Оплатить: /pay. После оплаты пришлите скриншот в чат."
+            "Оплатить: /pay. После оплаты пришлите скриншот в чат.\n\n"
+            f"{CANCEL_REGISTRATION_FOOTER}"
         )
     raise ValueError(f"unknown reminder kind: {kind}")
 
@@ -179,8 +296,8 @@ def kind_label_ru(kind: str) -> str:
 
 VOLUNTEER_OPTIONS_TEXT = (
     "Если хотите помочь вместо взноса или в дополнение — напишите "
-    "организатору <b>@mariikors</b>. Мария решает индивидуально "
-    "(скидка / бесплатный вход / волонтёрство).\n\n"
+    "организатору <b>@mariikors</b>. Можно договориться на "
+    "скидку / бесплатный вход / волонтёрство.\n\n"
     "Примеры задач:\n"
     "• проверка бейджей на входе\n"
     "• помощь с готовкой / уборкой / орг. делами\n"

--- a/src/payment_timeline.py
+++ b/src/payment_timeline.py
@@ -15,6 +15,9 @@ FOOD_DAYS_BEFORE = 4
 BADGE_DAYS_BEFORE = 2
 DEADLINE_HOUR = 6  # 06:00
 
+# Admin gets a summary 1 calendar day before each user-facing reminder day.
+ADMIN_PREVIEW_DAYS_BEFORE_REMINDER = 1
+
 
 def _as_date(value: Any) -> Optional[date]:
     if value is None:
@@ -35,7 +38,9 @@ def event_date(event: dict) -> Optional[date]:
     return _as_date(event.get("date"))
 
 
-def deadline_at(event: dict, days_before: int, hour: int = DEADLINE_HOUR) -> Optional[datetime]:
+def deadline_at(
+    event: dict, days_before: int, hour: int = DEADLINE_HOUR
+) -> Optional[datetime]:
     """Instant after which the “late” rule applies (06:00 on that morning)."""
     d = event_date(event)
     if d is None:
@@ -100,23 +105,47 @@ def pay_later_message(event: dict, now: Optional[datetime] = None) -> str:
     )
 
 
+def _deadline_for_kind(event: dict, kind: str) -> Optional[datetime]:
+    if kind == "d4":
+        return food_deadline(event)
+    if kind == "d2":
+        return badge_deadline(event)
+    raise ValueError(f"unknown reminder kind: {kind}")
+
+
 def reminder_kind_for_event(
     event: dict, now: Optional[datetime] = None
 ) -> Optional[str]:
     """Return ``d4`` or ``d2`` if *now* falls on that reminder calendar day.
 
     Reminder day = calendar day of the corresponding 06:00 deadline
-    (D-4 food planning day, D-2 badge day).
+    (D-4 food planning day, D-2 badge day). Prefer d4 if both somehow collide.
     """
     now = now or datetime.now()
+    today = now.date()
     food = food_deadline(event)
     badge = badge_deadline(event)
-    today = now.date()
     if food and today == food.date():
         return "d4"
     if badge and today == badge.date():
         return "d2"
     return None
+
+
+def admin_preview_kinds_for_event(
+    event: dict, now: Optional[datetime] = None
+) -> list[str]:
+    """Kinds whose user-reminder day is **tomorrow** (admin preview day)."""
+    now = now or datetime.now()
+    tomorrow = now.date() + timedelta(days=ADMIN_PREVIEW_DAYS_BEFORE_REMINDER)
+    kinds: list[str] = []
+    food = food_deadline(event)
+    badge = badge_deadline(event)
+    if food and tomorrow == food.date():
+        kinds.append("d4")
+    if badge and tomorrow == badge.date():
+        kinds.append("d2")
+    return kinds
 
 
 def reminder_message(kind: str, event: dict, city: str) -> str:
@@ -137,6 +166,14 @@ def reminder_message(kind: str, event: dict, city: str) -> str:
             "Оплатить: /pay. После оплаты пришлите скриншот в чат."
         )
     raise ValueError(f"unknown reminder kind: {kind}")
+
+
+def kind_label_ru(kind: str) -> str:
+    if kind == "d4":
+        return "D-4 (еда / 4 дня)"
+    if kind == "d2":
+        return "D-2 (бейдж / 2 дня)"
+    return kind
 
 
 VOLUNTEER_OPTIONS_TEXT = (

--- a/src/payment_timeline.py
+++ b/src/payment_timeline.py
@@ -4,6 +4,7 @@ Deadlines are at 06:00 on the calendar day N days before the event date
 (buffer: “before six in the morning”). Timezone-naive datetimes are treated
 as local wall time of the stored event date.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/reminder_scheduler.py
+++ b/src/reminder_scheduler.py
@@ -1,0 +1,63 @@
+"""APScheduler hook: daily payment reminder tick (admin preview + auto-send)."""
+from __future__ import annotations
+
+from typing import Optional
+
+from loguru import logger
+
+_scheduler = None
+
+
+def start_reminder_scheduler(app, bot, *, hour: int = 9, minute: int = 0) -> None:
+    """Start a singleton AsyncIOScheduler (no-op if already running)."""
+    global _scheduler
+    if _scheduler is not None:
+        logger.info("payment reminder scheduler already running")
+        return
+
+    try:
+        from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    except ImportError:
+        logger.error("apscheduler not installed; payment reminders will not auto-run")
+        return
+
+    from src.payment_reminders import daily_reminder_tick
+
+    scheduler = AsyncIOScheduler()
+
+    async def _job():
+        try:
+            await daily_reminder_tick(app, bot)
+        except Exception:
+            logger.exception("daily_reminder_tick failed")
+
+    scheduler.add_job(
+        _job,
+        trigger="cron",
+        hour=hour,
+        minute=minute,
+        id="payment_reminders_daily",
+        replace_existing=True,
+        misfire_grace_time=3600,
+    )
+    # Hourly safety net: same flags make it idempotent.
+    scheduler.add_job(
+        _job,
+        trigger="cron",
+        minute=15,
+        id="payment_reminders_hourly",
+        replace_existing=True,
+        misfire_grace_time=600,
+    )
+    scheduler.start()
+    _scheduler = scheduler
+    logger.info(
+        f"payment reminder scheduler started (daily {hour:02d}:{minute:02d} + hourly :15)"
+    )
+
+
+def stop_reminder_scheduler() -> None:
+    global _scheduler
+    if _scheduler is not None:
+        _scheduler.shutdown(wait=False)
+        _scheduler = None

--- a/src/reminder_scheduler.py
+++ b/src/reminder_scheduler.py
@@ -1,7 +1,7 @@
 """APScheduler hook: daily payment reminder tick (admin preview + auto-send)."""
+
 from __future__ import annotations
 
-from typing import Optional
 
 from loguru import logger
 

--- a/src/router.py
+++ b/src/router.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional
 from src.app import App, RegisteredUser, GraduateType, PAYMENT_STATUS_MAP
 from src.event_images import send_event_image
 from src.routers.admin import admin_handler
+from src.ticket_cards import is_ticket_unlocked, send_paid_ticket_card
 from botspot import commands_menu
 from src.user_interactions import ask_user, ask_user_choice
 from botspot.utils import send_safe, is_admin
@@ -1758,6 +1759,15 @@ def _format_payment_status_line(reg: Dict, event, graduate_type: str) -> str:
     return line
 
 
+def _format_ticket_status_line(reg: Dict) -> str:
+    if is_ticket_unlocked(reg):
+        return "🎟 Именной билет действителен для входа и доступен ниже.\n"
+    return (
+        "🎟 Заявка сохранена; действующего билета пока нет. "
+        "Именной билет появится после подтверждения оплаты.\n"
+    )
+
+
 def _format_registration_status_text(registrations, events_by_reg, app: App) -> str:
     status_text = "📋 Ваши регистрации:\n\n"
     for reg, event in zip(registrations, events_by_reg):
@@ -1781,6 +1791,7 @@ def _format_registration_status_text(registrations, events_by_reg, app: App) -> 
             )
 
         status_text += _format_payment_status_line(reg, event, graduate_type)
+        status_text += _format_ticket_status_line(reg)
         status_text += "\n"
     return status_text
 
@@ -1827,6 +1838,10 @@ async def status_handler(message: Message, state: FSMContext, app: App):
         status_text += "Следите за новостями в группе школы, чтобы не пропустить следующие встречи."
 
     await send_safe(message.chat.id, status_text, reply_markup=ReplyKeyboardRemove())
+
+    for registration, event in zip(registrations, events_by_reg):
+        if is_ticket_unlocked(registration):
+            await send_paid_ticket_card(message.chat.id, registration, event)
 
 
 async def _status_no_registrations(message: Message, app: App):

--- a/src/router.py
+++ b/src/router.py
@@ -1998,7 +1998,7 @@ async def start_handler(message: Message, state: FSMContext, app: App):
                 state=state,
             )
             if want_register:
-                existing_registration = await app.get_user_registration(
+                existing_registration = await app.get_profile_for_reuse(
                     message.from_user.id
                 )
                 await register_user(
@@ -2013,7 +2013,8 @@ async def start_handler(message: Message, state: FSMContext, app: App):
     if active_registrations:
         await handle_registered_user(message, state, active_registrations[0], app)
     else:
-        existing_registration = await app.get_user_registration(message.from_user.id)
+        # Soft-deleted (e.g. «too expensive») still prefill name/year on re-register.
+        existing_registration = await app.get_profile_for_reuse(message.from_user.id)
         if len(upcoming_events) == 1:
             await _show_single_event_welcome(
                 message, state, app, upcoming_events[0], existing_registration

--- a/src/routers/_events_helpers.py
+++ b/src/routers/_events_helpers.py
@@ -89,12 +89,17 @@ def _format_event_summary(event: dict, reg_count: int = 0) -> str:
             f"🎓 Бесплатно для: {', '.join(n for n in names if n is not None)}"
         )
 
-    # Early bird info
+    # Early bird info (cutoff = food planning D-4 06:00)
     eb_discount = event.get("early_bird_discount", 0)
-    eb_deadline = event.get("early_bird_deadline")
     if eb_discount > 0:
-        deadline_str = eb_deadline.strftime("%d.%m.%Y") if eb_deadline else "не указан"
-        lines.append(f"🐦 Ранняя регистрация: скидка {eb_discount}₽ до {deadline_str}")
+        from src.payment_timeline import early_bird_deadline_at, format_deadline_ru
+
+        eb_at = early_bird_deadline_at(event)
+        deadline_str = format_deadline_ru(eb_at) if eb_at else "как срок заказа еды (D-4)"
+        lines.append(
+            f"🐦 Ранняя регистрация: скидка {eb_discount}₽ до {deadline_str} "
+            f"(= срок заказа еды)"
+        )
 
     # Guest settings
     if event.get("guests_enabled"):

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -32,74 +32,59 @@ router = Router()
 # Helper function for calculating median
 
 
-async def admin_handler(message: Message, state: FSMContext, app: App):
+_ADMIN_SUBMENUS = {
+    "management": (
+        "Управление:",
+        {
+            "manage_events": "Управление встречами",
+            "register_payment": "Зарегистрировать оплату (за другого участника)",
+            "discretionary": "Скидка / бесплатный вход (решение Марии)",
+            "payment_reminders": "Напоминания об оплате (D-4 / D-2)",
+            "export": "Экспортировать данные",
+        },
+    ),
+    "communication": (
+        "Коммуникации:",
+        {
+            "notify_users": "Рассылка пользователям",
+            "announce_season": "Анонс нового сезона встреч",
+        },
+    ),
+    "stats": (
+        "Статистика и аналитика:",
+        {
+            "view_stats": "Статистика (подробно)",
+            "view_simple_stats": "Статистика (кратко)",
+            "view_year_stats": "По годам выпуска",
+            "five_year_stats": "По пятилеткам выпуска",
+            "payment_stats": "Диаграмма оплат",
+        },
+    ),
+}
+
+
+async def _resolve_admin_submenu(
+    chat_id: int, state: FSMContext, response: Optional[str]
+) -> Optional[str]:
+    if response not in _ADMIN_SUBMENUS:
+        return response
+    title, choices = _ADMIN_SUBMENUS[response]
+    return await ask_user_choice(
+        chat_id, title, choices=choices, state=state, timeout=None
+    )
+
+
+async def _dispatch_admin_action(
+    message: Message, state: FSMContext, app: App, response: Optional[str]
+) -> None:
     from src.routers.stats import (
-        show_stats,
-        show_simple_stats,
-        show_year_stats,
         show_five_year_stats,
         show_payment_stats,
+        show_simple_stats,
+        show_stats,
+        show_year_stats,
     )
 
-    response = await ask_user_choice(
-        message.chat.id,
-        "Вы администратор бота. Что вы хотите сделать?",
-        choices={
-            "register": "Протестировать бота (обычный сценарий)",
-            "management": "Управление",
-            "communication": "Коммуникации",
-            "stats": "Статистика и аналитика",
-        },
-        state=state,
-        timeout=None,
-    )
-
-    # -- Management submenu --
-    if response == "management":
-        response = await ask_user_choice(
-            message.chat.id,
-            "Управление:",
-            choices={
-                "manage_events": "Управление встречами",
-                "register_payment": "Зарегистрировать оплату (за другого участника)",
-                "discretionary": "Скидка / бесплатный вход (решение Марии)",
-                "payment_reminders": "Напоминания об оплате (D-4 / D-2)",
-                "export": "Экспортировать данные",
-            },
-            state=state,
-            timeout=None,
-        )
-
-    # -- Communication submenu --
-    if response == "communication":
-        response = await ask_user_choice(
-            message.chat.id,
-            "Коммуникации:",
-            choices={
-                "notify_users": "Рассылка пользователям",
-                "announce_season": "Анонс нового сезона встреч",
-            },
-            state=state,
-            timeout=None,
-        )
-
-    # -- Stats submenu --
-    if response == "stats":
-        response = await ask_user_choice(
-            message.chat.id,
-            "Статистика и аналитика:",
-            choices={
-                "view_stats": "Статистика (подробно)",
-                "view_simple_stats": "Статистика (кратко)",
-                "view_year_stats": "По годам выпуска",
-                "five_year_stats": "По пятилеткам выпуска",
-                "payment_stats": "Диаграмма оплат",
-            },
-            state=state,
-            timeout=None,
-        )
-
-    # -- Dispatch --
     if response == "manage_events":
         from src.routers.events import manage_events_handler
 
@@ -130,6 +115,23 @@ async def admin_handler(message: Message, state: FSMContext, app: App):
         await show_five_year_stats(message, app=app)
     elif response == "payment_stats":
         await show_payment_stats(message, app=app)
+
+
+async def admin_handler(message: Message, state: FSMContext, app: App):
+    response = await ask_user_choice(
+        message.chat.id,
+        "Вы администратор бота. Что вы хотите сделать?",
+        choices={
+            "register": "Протестировать бота (обычный сценарий)",
+            "management": "Управление",
+            "communication": "Коммуникации",
+            "stats": "Статистика и аналитика",
+        },
+        state=state,
+        timeout=None,
+    )
+    response = await _resolve_admin_submenu(message.chat.id, state, response)
+    await _dispatch_admin_action(message, state, app, response)
     # For "register", continue with normal flow
     return response
 

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -281,7 +281,8 @@ async def admin_register_payment(message: Message, state: FSMContext, app: App):
             bot = get_dependency_manager().bot
             await bot.send_message(
                 int(target_user_id),
-                f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!",
+                f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!\n"
+                "Именной билет доступен по команде /status.",
             )
         except Exception as e:
             logger.warning(f"Could not notify user {target_user_id}: {e}")

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -24,6 +24,19 @@ from botspot.utils.admin_filter import AdminFilter
 class PaymentInfo(BaseModel):
     amount: Optional[int]
     is_valid: bool  # Whether there's a clear payment amount in the document
+    # True if receipt looks like a transfer to Maria (name/phone from env).
+    # False → treat as website / card payment (CloudPayments, etc.).
+    paid_to_maria: bool = False
+    method_reason: Optional[str] = None  # short free-text evidence for admins/logs
+
+    @property
+    def payment_method(self) -> str:
+        """Canonical method key used elsewhere: on_site | to_maria."""
+        return "to_maria" if self.paid_to_maria else "on_site"
+
+
+# Sonnet: Haiku was cheaper but misclassified receipts; override via PAYMENT_PARSE_MODEL.
+DEFAULT_PAYMENT_PARSE_MODEL = "anthropic/claude-sonnet-4-6"
 
 
 router = Router()
@@ -786,17 +799,40 @@ async def normalize_db(message: Message, app: App):
 # else:
 #     file_type = "image/{file_name.split('.')[-1]}"
 async def extract_payment_from_image(
-    file_bytes: bytes, file_type: str = "image/jpeg"
+    file_bytes: bytes,
+    file_type: str = "image/jpeg",
+    *,
+    recipient_name: str | None = None,
+    recipient_phone: str | None = None,
+    model: str | None = None,
 ) -> PaymentInfo:
-    """Extract payment amount from an image or PDF using Claude Vision via litellm"""
+    """Extract amount + payment destination from image/PDF via vision (litellm).
+
+    Destination: if receipt shows *recipient_name* / *recipient_phone* (Maria),
+    set ``paid_to_maria=True``; otherwise assume website payment.
+    """
     try:
-        # Define the system prompt for payment extraction
-        system_prompt = """You are a payment receipt analyzer.
-        Your task is to extract ONLY the payment amount in rubles from the receipt image or PDF.
+        name = (recipient_name or "").strip() or "(not provided)"
+        phone = (recipient_phone or "").strip() or "(not provided)"
+        system_prompt = f"""You are a payment receipt analyzer for a Russian meetup.
+Extract:
+1) payment amount in rubles (integer), if clearly visible
+2) whether this looks like a bank/SBP/phone transfer TO Maria (personal transfer),
+   vs a website / card / CloudPayments / online-acquiring payment.
 
-        If you cannot determine the amount or if it's ambiguous, set amount to null and is_valid to false."""
+Maria's payment details (match loosely — formatting varies):
+- Name: {name}
+- Phone: {phone}
 
-        # For images, encode to base64
+Set paid_to_maria=true if the recipient matches this name and/or phone
+(phone digits may appear with +7/8/spaces/dashes; name may be partial or transliterated).
+Set paid_to_maria=false for website payments, card checkouts, CloudPayments,
+merchant names unrelated to Maria, or when destination is unclear.
+method_reason: one short phrase in Russian or English explaining the destination guess.
+
+If amount is missing or ambiguous: amount=null, is_valid=false.
+Destination can still be set when amount is unclear."""
+
         encoded_file = base64.b64encode(file_bytes).decode("utf-8")
         if file_type not in ["image/jpeg", "image/png", "application/pdf"]:
             raise ValueError(f"Unsupported file type: {file_type}")
@@ -808,7 +844,10 @@ async def extract_payment_from_image(
                 "content": [
                     {
                         "type": "text",
-                        "text": "Please extract the payment amount from this receipt:",
+                        "text": (
+                            "Extract the payment amount and whether this receipt "
+                            "is a transfer to Maria vs a website payment."
+                        ),
                     },
                     {
                         "type": "image_url",
@@ -818,18 +857,18 @@ async def extract_payment_from_image(
             },
         ]
 
-        # Make the API call with the Pydantic model
+        use_model = model or DEFAULT_PAYMENT_PARSE_MODEL
         response = await acompletion(
-            model="anthropic/claude-sonnet-4-6",
+            model=use_model,
             messages=messages,
-            max_tokens=100,
+            max_tokens=200,
             response_format=PaymentInfo,
         )
 
         return PaymentInfo(**json.loads(response.choices[0].message.content))  # type: ignore[union-attr]
     except Exception as e:
         logger.error(f"Error extracting payment amount: {e}")
-        return PaymentInfo(amount=None, is_valid=False)
+        return PaymentInfo(amount=None, is_valid=False, paid_to_maria=False)
 
 
 def _get_file_info(response) -> Optional[tuple]:
@@ -902,16 +941,27 @@ async def parse_payment_handler(message: Message, state: FSMContext):
             await status_msg.edit_text("❌ Не удалось скачать файл")
             return
 
-        # Extract payment information directly from the file
-        result = await extract_payment_from_image(file_data, file_type)
+        from src.app import App
 
-        # Format the response
+        settings = App().settings
+        result = await extract_payment_from_image(
+            file_data,
+            file_type,
+            recipient_name=settings.payment_name,
+            recipient_phone=settings.payment_phone_number,
+            model=getattr(settings, "payment_parse_model", None),
+        )
+
         if result.is_valid:
             response_text = f"✅ Обнаружен платеж на сумму: <b>{result.amount}</b> руб."
         else:
             response_text = "❌ Не удалось извлечь сумму платежа"
 
-        # Update the status message with the results
+        method_label = "Маше (перевод)" if result.paid_to_maria else "сайт / карта"
+        response_text += f"\n📍 Куда (AI): <b>{method_label}</b>"
+        if result.method_reason:
+            response_text += f"\n💬 {result.method_reason}"
+
         await status_msg.edit_text(response_text, parse_mode="HTML")
 
     except Exception as e:

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -109,7 +109,7 @@ async def admin_handler(message: Message, state: FSMContext, app: App):
     elif response == "discretionary":
         await admin_discretionary_payment(message, state, app)
     elif response == "payment_reminders":
-        await admin_run_payment_reminders(message, app)
+        await admin_payment_reminders_menu(message, state, app)
     elif response == "export":
         await export_handler(message, state, app=app)
     elif response == "notify_users":
@@ -431,31 +431,201 @@ async def admin_discretionary_payment(
     await app.export_registered_users_to_google_sheets()
 
 
-async def admin_run_payment_reminders(message: Message, app: App) -> None:
-    """Run D-4 / D-2 payment reminder scan (idempotent flags on registrations)."""
+async def admin_payment_reminders_menu(
+    message: Message, state: FSMContext, app: App
+) -> None:
+    """Admin tools: plan, pause/unpause, send now, force daily tick."""
+    chat_id = message.chat.id
+    action = await ask_user_choice(
+        chat_id,
+        "Напоминания об оплате (D-4 еда / D-2 бейдж).\n"
+        "Авто: ежедневно ~09:00 + hourly; за день — превью админам.",
+        choices={
+            "plan": "Расписание / превью ближайших",
+            "pause": "Пауза (не слать автоматически)",
+            "unpause": "Снять паузу",
+            "send_now": "Отправить сейчас (выбрать встречу)",
+            "tick": "Запустить тик сейчас (превью+должные)",
+            "cancel": "Назад",
+        },
+        state=state,
+        timeout=None,
+    )
+    if action in (None, "cancel"):
+        await send_safe(chat_id, "Ок.")
+        return
+    if action == "plan":
+        await _admin_reminders_show_plan(message, app)
+    elif action == "pause":
+        await _admin_reminders_set_pause(message, state, app, paused=True)
+    elif action == "unpause":
+        await _admin_reminders_set_pause(message, state, app, paused=False)
+    elif action == "send_now":
+        await _admin_reminders_send_now(message, state, app)
+    elif action == "tick":
+        await admin_run_payment_reminders(message, app)
+
+
+async def _admin_reminders_show_plan(message: Message, app: App) -> None:
+    from src.payment_reminders import list_upcoming_reminder_plan
+
+    plan = await list_upcoming_reminder_plan(app, days_ahead=14)
+    if not plan:
+        await send_safe(message.chat.id, "В ближайшие 14 дней напоминаний не запланировано.")
+        return
+    lines = ["📅 Ближайшие авто-напоминания:\n"]
+    for row in plan:
+        pause = " ⏸" if row["paused"] else ""
+        lines.append(
+            f"• {row['send_day']} {row['label']}{pause} — {row['city']}\n"
+            f"  превью админам: {row['preview_day']} · "
+            f"получателей ~{row['recipient_count']}\n"
+            f"  id={row['event_id'][:10]}…"
+        )
+    # First full text preview (so admins see copy)
+    first = plan[0]
+    lines.append("\n——— пример текста (первый в списке) ——-")
+    lines.append(first["text"])
+    await send_safe(message.chat.id, "\n".join(lines))
+
+
+async def _pick_event_and_kind(
+    chat_id: int, state: FSMContext, app: App, plan_only: bool = False
+) -> Optional[tuple[str, str, str]]:
+    """Returns (event_id, kind, city) or None."""
+    from src.payment_reminders import list_upcoming_reminder_plan
+    from src.payment_timeline import kind_label_ru
+
+    if plan_only:
+        plan = await list_upcoming_reminder_plan(app, days_ahead=30)
+        if not plan:
+            await send_safe(chat_id, "Нет предстоящих напоминаний.")
+            return None
+        choices = {}
+        for i, row in enumerate(plan):
+            key = f"{i}"
+            pause = " ⏸" if row["paused"] else ""
+            choices[key] = (
+                f"{row['send_day']} {row['label']}{pause} — {row['city']} "
+                f"({row['recipient_count']} чел.)"
+            )
+        choices["cancel"] = "Отмена"
+        pick = await ask_user_choice(
+            chat_id, "Выберите напоминание:", choices=choices, state=state, timeout=None
+        )
+        if pick in (None, "cancel"):
+            return None
+        row = plan[int(pick)]
+        return row["event_id"], row["kind"], row["city"]
+
+    # All non-archived events × kinds
+    selected = await _select_event_for_payment(chat_id, state, app)
+    if not selected:
+        return None
+    event = await app.get_event_by_id(selected)
+    city = (event or {}).get("city", "?")
+    kind = await ask_user_choice(
+        chat_id,
+        f"{city}: какой тип?",
+        choices={
+            "d4": kind_label_ru("d4"),
+            "d2": kind_label_ru("d2"),
+            "cancel": "Отмена",
+        },
+        state=state,
+        timeout=None,
+    )
+    if kind in (None, "cancel"):
+        return None
+    return selected, kind, city
+
+
+async def _admin_reminders_set_pause(
+    message: Message, state: FSMContext, app: App, *, paused: bool
+) -> None:
+    from src.payment_reminders import set_paused
+    from src.payment_timeline import kind_label_ru
+
+    pick = await _pick_event_and_kind(message.chat.id, state, app, plan_only=True)
+    if not pick:
+        await send_safe(message.chat.id, "Отменено.")
+        return
+    event_id, kind, city = pick
+    ctrl = await set_paused(app, event_id, kind, paused)
+    state_ru = "на паузе ⏸" if ctrl.get("paused") else "активно ▶"
+    await send_safe(
+        message.chat.id,
+        f"{city} · {kind_label_ru(kind)}: теперь <b>{state_ru}</b>.",
+    )
+
+
+async def _admin_reminders_send_now(
+    message: Message, state: FSMContext, app: App
+) -> None:
     from botspot.core.dependency_manager import get_dependency_manager
     from src.payment_reminders import send_payment_reminders
+    from src.payment_timeline import kind_label_ru
+
+    pick = await _pick_event_and_kind(message.chat.id, state, app, plan_only=False)
+    if not pick:
+        await send_safe(message.chat.id, "Отменено.")
+        return
+    event_id, kind, city = pick
+    confirm = await ask_user_choice(
+        message.chat.id,
+        f"Отправить <b>сейчас</b> {kind_label_ru(kind)} для {city} "
+        f"(только тем, кому ещё не слали; пауза игнорируется)?",
+        choices={"yes": "Да, отправить", "no": "Отмена"},
+        state=state,
+        timeout=None,
+    )
+    if confirm != "yes":
+        await send_safe(message.chat.id, "Отменено.")
+        return
+    bot = get_dependency_manager().bot
+    stats = await send_payment_reminders(
+        app,
+        bot,
+        force_event_id=event_id,
+        force_kind=kind,
+        respect_pause=False,
+        only_due_today=False,
+    )
+    await send_safe(
+        message.chat.id,
+        f"Отправлено сейчас ({kind_label_ru(kind)} / {city}):\n"
+        f"d4={stats['d4']} d2={stats['d2']} "
+        f"skipped={stats['skipped']} errors={stats['errors']}",
+    )
+
+
+async def admin_run_payment_reminders(message: Message, app: App) -> None:
+    """Force daily tick: admin previews + due user sends (respects pause)."""
+    from botspot.core.dependency_manager import get_dependency_manager
+    from src.payment_reminders import daily_reminder_tick
 
     chat_id = message.chat.id
     await send_safe(
         chat_id,
-        "Запускаю проверку напоминаний (D-4 еда / D-2 бейдж)…",
+        "Запускаю тик: превью «завтра» + рассылка должных на сегодня…",
     )
     try:
         bot = get_dependency_manager().bot
-        stats = await send_payment_reminders(app, bot, dry_run=False)
+        result = await daily_reminder_tick(app, bot)
     except Exception as e:
-        logger.exception("payment reminders failed")
+        logger.exception("payment reminders tick failed")
         await send_safe(chat_id, f"Ошибка: {e}")
         return
+    prev = result["preview"]
+    send = result["send"]
     await send_safe(
         chat_id,
-        "Напоминания:\n"
-        f"• событий в окне D-4/D-2: {stats['events']}\n"
-        f"• отправлено D-4: {stats['d4']}\n"
-        f"• отправлено D-2: {stats['d2']}\n"
-        f"• пропущено (уже слали / нет user_id): {stats['skipped']}\n"
-        f"• ошибок: {stats['errors']}",
+        "Тик готов.\n"
+        f"Превью админам: {prev.get('previews', 0)} "
+        f"(skip {prev.get('skipped', 0)}, err {prev.get('errors', 0)})\n"
+        f"Пользователям: d4={send.get('d4', 0)} d2={send.get('d2', 0)} "
+        f"paused={send.get('paused', 0)} skipped={send.get('skipped', 0)} "
+        f"errors={send.get('errors', 0)}",
     )
 
 

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import Optional
+from typing import Mapping, Optional
 
 from aiogram import Router
 from aiogram.filters import Command
@@ -12,6 +12,7 @@ from litellm import acompletion
 from loguru import logger
 from pydantic import BaseModel
 from src.app import App
+from src.ticket_cards import send_paid_ticket_card
 from botspot import commands_menu
 from botspot.components.qol.bot_commands_menu import Visibility
 from src.user_interactions import ask_user_choice, ask_user_raw
@@ -247,6 +248,29 @@ async def _confirm_payment_amount(
         return None
 
 
+async def _send_admin_confirmed_ticket(
+    app: App, target_user_id: int, event_id: str
+) -> None:
+    """Re-read authoritative state and attempt ticket delivery without blocking payment."""
+
+    try:
+        registration = await app.collection.find_one(
+            {"user_id": target_user_id, "event_id": event_id}
+        )
+        if not isinstance(registration, Mapping):
+            logger.warning(
+                f"Could not re-read registration for ticket delivery: "
+                f"user={target_user_id}, event={event_id}"
+            )
+            return
+        event = await app.get_event_for_registration(registration)
+        await send_paid_ticket_card(target_user_id, registration, event)
+    except Exception as e:
+        logger.warning(
+            f"Could not deliver confirmed ticket for user {target_user_id}: {e}"
+        )
+
+
 async def admin_register_payment(message: Message, state: FSMContext, app: App):
     """Admin flow: select event → pick unpaid user → confirm payment."""
     chat_id = message.chat.id
@@ -282,10 +306,13 @@ async def admin_register_payment(message: Message, state: FSMContext, app: App):
             await bot.send_message(
                 int(target_user_id),
                 f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!\n"
-                "Именной билет доступен по команде /status.",
+                "Именной билет отправляем следующим сообщением. "
+                "Если он не появится, откройте /status.",
             )
         except Exception as e:
             logger.warning(f"Could not notify user {target_user_id}: {e}")
+
+        await _send_admin_confirmed_ticket(app, int(target_user_id), selected)
     else:
         # No user_id — update by registration _id
         await app.collection.update_one(

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -62,6 +62,8 @@ async def admin_handler(message: Message, state: FSMContext, app: App):
             choices={
                 "manage_events": "Управление встречами",
                 "register_payment": "Зарегистрировать оплату (за другого участника)",
+                "discretionary": "Скидка / бесплатный вход (решение Марии)",
+                "payment_reminders": "Напоминания об оплате (D-4 / D-2)",
                 "export": "Экспортировать данные",
             },
             state=state,
@@ -104,6 +106,10 @@ async def admin_handler(message: Message, state: FSMContext, app: App):
         await manage_events_handler(message, state, app=app)
     elif response == "register_payment":
         await admin_register_payment(message, state, app)
+    elif response == "discretionary":
+        await admin_discretionary_payment(message, state, app)
+    elif response == "payment_reminders":
+        await admin_run_payment_reminders(message, app)
     elif response == "export":
         await export_handler(message, state, app=app)
     elif response == "notify_users":
@@ -288,43 +294,169 @@ async def admin_register_payment(message: Message, state: FSMContext, app: App):
     if amount is None:
         return
 
-    if target_user_id:
-        await app.update_payment_status(
-            user_id=int(target_user_id),
-            event_id=selected,
-            status="confirmed",
-            payment_amount=amount,
-            admin_id=message.from_user.id if message.from_user else None,
-            admin_username=message.from_user.username if message.from_user else None,
-        )
-
-        # Notify the user
-        try:
-            from botspot.core.dependency_manager import get_dependency_manager
-
-            bot = get_dependency_manager().bot
-            await bot.send_message(
-                int(target_user_id),
-                f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!\n"
-                "Именной билет отправляем следующим сообщением. "
-                "Если он не появится, откройте /status.",
-            )
-        except Exception as e:
-            logger.warning(f"Could not notify user {target_user_id}: {e}")
-
-        await _send_admin_confirmed_ticket(app, int(target_user_id), selected)
-    else:
-        # No user_id — update by registration _id
-        await app.collection.update_one(
-            {"_id": reg["_id"]},
-            {"$set": {"payment_status": "confirmed", "payment_amount": amount}},
-        )
-
+    await _apply_admin_confirmed_payment(
+        app,
+        message,
+        reg=reg,
+        target_user_id=target_user_id,
+        target_name=target_name,
+        event_id=selected,
+        amount=amount,
+        admin_comment=None,
+        user_note=(
+            f"Ваша оплата {amount}₽ подтверждена администратором. Спасибо!\n"
+            "Именной билет отправляем следующим сообщением. "
+            "Если он не появится, откройте /status."
+        ),
+    )
     await send_safe(
         chat_id,
         f"Оплата {amount}₽ подтверждена для {target_name}.",
     )
     await app.export_registered_users_to_google_sheets()
+
+
+async def _apply_admin_confirmed_payment(
+    app: App,
+    message: Message,
+    *,
+    reg: dict,
+    target_user_id,
+    target_name: str,
+    event_id: str,
+    amount: int,
+    admin_comment: Optional[str],
+    user_note: str,
+) -> None:
+    if target_user_id:
+        kwargs = dict(
+            user_id=int(target_user_id),
+            event_id=event_id,
+            status="confirmed",
+            payment_amount=amount,
+            admin_id=message.from_user.id if message.from_user else None,
+            admin_username=message.from_user.username if message.from_user else None,
+        )
+        if admin_comment:
+            kwargs["admin_comment"] = admin_comment
+        await app.update_payment_status(**kwargs)
+        try:
+            from botspot.core.dependency_manager import get_dependency_manager
+
+            bot = get_dependency_manager().bot
+            await bot.send_message(int(target_user_id), user_note)
+        except Exception as e:
+            logger.warning(f"Could not notify user {target_user_id}: {e}")
+        await _send_admin_confirmed_ticket(app, int(target_user_id), event_id)
+    else:
+        from datetime import datetime
+
+        update = {
+            "payment_status": "confirmed",
+            "payment_amount": amount,
+            "payment_verified_at": datetime.now().isoformat(),
+        }
+        if admin_comment:
+            update["admin_comment"] = admin_comment
+        await app.collection.update_one({"_id": reg["_id"]}, {"$set": update})
+
+
+async def admin_discretionary_payment(
+    message: Message, state: FSMContext, app: App
+) -> None:
+    """Maria/admin: free entry or custom discounted amount for one registrant."""
+    chat_id = message.chat.id
+    selected = await _select_event_for_payment(chat_id, state, app)
+    if not selected:
+        return
+
+    user_result = await _select_unpaid_user(chat_id, state, app, selected)
+    if not user_result:
+        return
+    reg, target_user_id, target_name = user_result
+
+    mode = await ask_user_choice(
+        chat_id,
+        f"Участник: {target_name}\n"
+        "Решение по взносу (скидка / бесплатно — на усмотрение Марии):",
+        choices={
+            "free": "Бесплатный вход (0 ₽, confirmed)",
+            "discount": "Своя сумма (скидка) → confirmed",
+            "cancel": "Отмена",
+        },
+        state=state,
+        timeout=None,
+    )
+    if mode in (None, "cancel"):
+        await send_safe(chat_id, "Отменено.")
+        return
+
+    if mode == "free":
+        amount = 0
+        comment = "discretionary_free"
+        user_note = (
+            "Для вас вход на встречу подтверждён без оплаты "
+            "(решение организаторов). Спасибо, что с нами!\n"
+            "Именной билет — следующим сообщением (или /status)."
+        )
+    else:
+        amount = await _confirm_payment_amount(
+            chat_id, state, f"{target_name} (скидочная сумма)"
+        )
+        if amount is None:
+            return
+        comment = f"discretionary_discount:{amount}"
+        user_note = (
+            f"Ваш взнос зафиксирован как {amount}₽ "
+            f"(индивидуальное решение организаторов). Спасибо!\n"
+            "Именной билет — следующим сообщением (или /status)."
+        )
+
+    await _apply_admin_confirmed_payment(
+        app,
+        message,
+        reg=reg,
+        target_user_id=target_user_id,
+        target_name=target_name,
+        event_id=selected,
+        amount=amount,
+        admin_comment=comment,
+        user_note=user_note,
+    )
+    await send_safe(
+        chat_id,
+        f"Готово: {target_name} — "
+        f"{'бесплатно' if amount == 0 else f'{amount}₽ (скидка)'}, статус confirmed.",
+    )
+    await app.export_registered_users_to_google_sheets()
+
+
+async def admin_run_payment_reminders(message: Message, app: App) -> None:
+    """Run D-4 / D-2 payment reminder scan (idempotent flags on registrations)."""
+    from botspot.core.dependency_manager import get_dependency_manager
+    from src.payment_reminders import send_payment_reminders
+
+    chat_id = message.chat.id
+    await send_safe(
+        chat_id,
+        "Запускаю проверку напоминаний (D-4 еда / D-2 бейдж)…",
+    )
+    try:
+        bot = get_dependency_manager().bot
+        stats = await send_payment_reminders(app, bot, dry_run=False)
+    except Exception as e:
+        logger.exception("payment reminders failed")
+        await send_safe(chat_id, f"Ошибка: {e}")
+        return
+    await send_safe(
+        chat_id,
+        "Напоминания:\n"
+        f"• событий в окне D-4/D-2: {stats['events']}\n"
+        f"• отправлено D-4: {stats['d4']}\n"
+        f"• отправлено D-2: {stats['d2']}\n"
+        f"• пропущено (уже слали / нет user_id): {stats['skipped']}\n"
+        f"• ошибок: {stats['errors']}",
+    )
 
 
 @commands_menu.add_command(

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -471,7 +471,9 @@ async def _admin_reminders_show_plan(message: Message, app: App) -> None:
 
     plan = await list_upcoming_reminder_plan(app, days_ahead=14)
     if not plan:
-        await send_safe(message.chat.id, "В ближайшие 14 дней напоминаний не запланировано.")
+        await send_safe(
+            message.chat.id, "В ближайшие 14 дней напоминаний не запланировано."
+        )
         return
     lines = ["📅 Ближайшие авто-напоминания:\n"]
     for row in plan:

--- a/src/routers/crm.py
+++ b/src/routers/crm.py
@@ -1,3 +1,5 @@
+import re
+
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.types import Message
@@ -319,12 +321,20 @@ async def _build_recipient_list(
             return list(active_ids | deleted_ids)
         ev = event_map.get(city_filter, {})
         city = ev.get("city", "")
-        active_ids = set(
-            await app.collection.distinct("user_id", {"target_city": city})
-        )
-        deleted_ids = set(
-            await app.deleted_users.distinct("user_id", {"target_city": city})
-        )
+        # Historical rows are reachable two ways: via any event (any season,
+        # any status) held in this city, and via legacy target_city values
+        # that embed the city name, e.g. "Пермь (Летняя встреча 2025)".
+        city_event_ids = [
+            str(e["_id"]) for e in await app.get_all_events() if e.get("city") == city
+        ]
+        history_query = {
+            "$or": [
+                {"event_id": {"$in": city_event_ids}},
+                {"target_city": {"$regex": f"^{re.escape(city)}"}},
+            ]
+        }
+        active_ids = set(await app.collection.distinct("user_id", history_query))
+        deleted_ids = set(await app.deleted_users.distinct("user_id", history_query))
         return list(active_ids | deleted_ids)
     # current
     if city_filter == "all":

--- a/src/routers/crm.py
+++ b/src/routers/crm.py
@@ -408,28 +408,10 @@ async def _send_announcements(users_ids: list, announcement_text: str) -> tuple:
     return sent_count, failed_count
 
 
-async def announce_new_season_handler(message: Message, state: FSMContext, app: App):
-    """Announce new meetup season to users with audience and city controls."""
-    if not message.from_user:
-        await send_safe(message.chat.id, "❌ Ошибка: не удалось определить отправителя")
-        return
-
-    enabled_events = await app.get_enabled_events()
-    if not enabled_events:
-        await send_safe(
-            message.chat.id,
-            "⚠️ Нет активных встреч. Сначала создайте встречи через /create_event",
-        )
-        return
-
-    events_preview = "📅 Текущие активные встречи:\n"
-    for ev in enabled_events:
-        from src.router import get_event_date_display
-
-        events_preview += f"  • {ev.get('city', '?')} ({get_event_date_display(ev)})\n"
-    await send_safe(message.chat.id, events_preview)
-
-    # Step 1: audience scope
+async def _season_collect_audience(
+    message: Message, state: FSMContext, app: App, enabled_events: list
+) -> Optional[tuple]:
+    """Return (audience, city_filter, event_map, user_ids) or None if cancelled."""
     audience = await ask_user_choice(
         message.chat.id,
         "Шаг 1: Кому отправить анонс?",
@@ -443,9 +425,8 @@ async def announce_new_season_handler(message: Message, state: FSMContext, app: 
     )
     if audience == "cancel":
         await send_safe(message.chat.id, "Операция отменена.")
-        return
+        return None
 
-    # Step 2: city/event filter
     city_choices: Dict[str, Any] = {"all": "Все города / встречи", "cancel": "Отмена"}
     event_map = {}
     for ev in enabled_events:
@@ -462,14 +443,52 @@ async def announce_new_season_handler(message: Message, state: FSMContext, app: 
     )
     if city_filter == "cancel":
         await send_safe(message.chat.id, "Операция отменена.")
-        return
+        return None
 
     target_user_ids = await _build_recipient_list(app, audience, city_filter, event_map)
     if not target_user_ids:
         await send_safe(message.chat.id, "❌ Нет пользователей для рассылки.")
+        return None
+    return audience, city_filter, event_map, target_user_ids
+
+
+def _season_audience_desc(audience: str, city_filter: str, event_map: dict) -> str:
+    desc = (
+        "все пользователи за всё время"
+        if audience == "all_time"
+        else "текущие зарегистрированные"
+    )
+    if city_filter != "all" and city_filter in event_map:
+        desc += f" ({event_map[city_filter].get('city', city_filter)})"
+    return desc
+
+
+async def announce_new_season_handler(message: Message, state: FSMContext, app: App):
+    """Announce new meetup season to users with audience and city controls."""
+    if not message.from_user:
+        await send_safe(message.chat.id, "❌ Ошибка: не удалось определить отправителя")
         return
 
-    # Step 3: link
+    enabled_events = await app.get_enabled_events()
+    if not enabled_events:
+        await send_safe(
+            message.chat.id,
+            "⚠️ Нет активных встреч. Сначала создайте встречи через /create_event",
+        )
+        return
+
+    from src.router import get_event_date_display
+
+    events_preview = "📅 Текущие активные встречи:\n"
+    for ev in enabled_events:
+        events_preview += f"  • {ev.get('city', '?')} ({get_event_date_display(ev)})\n"
+    await send_safe(message.chat.id, events_preview)
+
+    collected = await _season_collect_audience(message, state, app, enabled_events)
+    if collected is None:
+        return
+    audience, city_filter, event_map, target_user_ids = collected
+
     link_resp = await ask_user_raw(
         message.chat.id,
         "Шаг 3: Введите ссылку на пост (или 'нет' чтобы пропустить):",
@@ -480,21 +499,13 @@ async def announce_new_season_handler(message: Message, state: FSMContext, app: 
     if link_resp and link_resp.text and link_resp.text.strip().lower() != "нет":
         post_link = link_resp.text.strip()
 
-    default_message = _build_default_announcement(enabled_events, post_link)
-
-    # Step 4: text
-    announcement_text = await _get_announcement_text(message, state, default_message)
+    announcement_text = await _get_announcement_text(
+        message, state, _build_default_announcement(enabled_events, post_link)
+    )
     if announcement_text is None:
         return
 
-    audience_desc = (
-        "все пользователи за всё время"
-        if audience == "all_time"
-        else "текущие зарегистрированные"
-    )
-    if city_filter != "all" and city_filter in event_map:
-        audience_desc += f" ({event_map[city_filter].get('city', city_filter)})"
-
+    audience_desc = _season_audience_desc(audience, city_filter, event_map)
     confirm = await ask_user_confirmation(
         message.chat.id,
         f"⚠️ Отправить анонс {len(target_user_ids)} пользователям?\n"
@@ -519,7 +530,6 @@ async def announce_new_season_handler(message: Message, state: FSMContext, app: 
     sent_count, failed_count = await _send_announcements(
         target_user_ids, announcement_text
     )
-
     await status_msg.edit_text(
         f"✅ Анонс отправлен!\n\n"
         f"📊 Статистика:\n"

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -458,7 +458,9 @@ async def _handle_too_expensive(
                         "events",
                     )
                 except Exception as e:
-                    logger.warning(f"Could not log volunteer interest to events chat: {e}")
+                    logger.warning(
+                        f"Could not log volunteer interest to events chat: {e}"
+                    )
                 await send_safe(
                     message.chat.id,
                     "Отметили интерес. Напишите @mariikors — она решает "

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -19,6 +19,7 @@ from src import templates
 from src.app import App, GraduateType
 from src.router import is_admin, commands_menu, get_event_date_display
 from src.routers.admin import PaymentInfo
+from src.ticket_cards import send_paid_ticket_card
 from src.user_interactions import ask_user_raw, ask_user_choice, ask_user_choice_raw
 from botspot.utils import send_safe
 
@@ -1346,6 +1347,9 @@ async def confirm_payment_callback(callback_query: CallbackQuery, state: FSMCont
         payment_message += "Если у вас будет возможность, вы можете доплатить эту сумму позже, используя команду /pay."
 
     await send_safe(user_id, payment_message)
+
+    event = await app.get_event_for_registration(updated_registration)
+    await send_paid_ticket_card(user_id, updated_registration, event)
 
     if callback_query.message:
         user_info = f"{registration.get('username', user_id)} ({registration.get('full_name', 'Неизвестно')})"

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -192,15 +192,50 @@ def _season_adjective(event) -> str:
 
 
 def _check_early_bird(event) -> tuple[bool, object, int]:
-    early_bird_deadline = event.get("early_bird_deadline") if event else None
-    early_bird_discount_amount = event.get("early_bird_discount", 0) if event else 0
-    today = datetime.now()
-    is_early = (
-        early_bird_deadline
-        and today.date() <= early_bird_deadline.date()
-        and early_bird_discount_amount > 0
+    """Return (is_active, deadline_datetime|None, discount_amount).
+
+    Cutoff is shared with food planning (D-4 06:00) via payment_timeline.
+    """
+    from src.payment_timeline import early_bird_deadline_at, is_early_bird_active
+
+    if not event:
+        return False, None, 0
+    discount = int(event.get("early_bird_discount") or 0)
+    deadline = early_bird_deadline_at(event)
+    is_early = bool(discount > 0 and is_early_bird_active(event))
+    return is_early, deadline, discount if is_early else 0
+
+
+def _build_early_bird_payment_block(
+    *,
+    city: str,
+    formula: str,
+    price_label: str,
+    regular_amount: int,
+    discount: int,
+    discounted_amount: int,
+    deadline_display: str,
+    season: str,
+    include_formula: bool,
+) -> str:
+    """Price message when early bird is active: breakdown in collapsed quote."""
+    # Collapsed quote: formula + year price + discount (secondary detail).
+    quote_parts: list[str] = ["расчет оплаты"]
+    if include_formula:
+        quote_parts.append(f"{escape(str(city), quote=True)} → {escape(str(formula), quote=True)}")
+    quote_parts.append(
+        f"{escape(price_label, quote=True)}: {regular_amount} руб."
     )
-    return bool(is_early), early_bird_deadline, early_bird_discount_amount
+    quote_parts.append(f"При ранней регистрации скидка {discount} руб!")
+    quote_body = "\n".join(quote_parts)
+    # expandable = collapsed by default in Telegram clients that support it
+    return (
+        "💰 Оплата мероприятия\n\n"
+        f"<blockquote expandable>{quote_body}</blockquote>\n\n"
+        f"Итоговая цена со скидкой за раннюю регистрацию (до {escape(deadline_display, quote=True)}):\n"
+        f"<b>{discounted_amount} руб.</b>\n\n"
+        f"Очень ждём вас на {escape(season, quote=True)} встрече! 😊"
+    )
 
 
 async def _send_payment_info_messages(
@@ -219,6 +254,7 @@ async def _send_payment_info_messages(
     """Send payment info in two user-visible messages (price+guests, then how to pay)."""
     from botspot.core.dependency_manager import get_dependency_manager
     from src.pay_url import build_pay_url
+    from src.payment_timeline import format_deadline_ru
 
     deps = get_dependency_manager()
     await deps.bot.send_chat_action(chat_id=message.chat.id, action="typing")
@@ -226,13 +262,6 @@ async def _send_payment_info_messages(
 
     payment_formula = _build_payment_formula(event)
     chunks: list[str] = []
-
-    if graduate_type != GraduateType.NON_GRADUATE.value:
-        chunks.append(
-            templates.render(
-                event, "payment_intro", {"city": city, "formula": payment_formula}
-            ).strip()
-        )
 
     price_label = (
         "Минимальный взнос для вас"
@@ -242,25 +271,31 @@ async def _send_payment_info_messages(
 
     is_early, early_bird_deadline, early_bird_discount_amount = _check_early_bird(event)
     season = _season_adjective(event)
+    include_formula = graduate_type != GraduateType.NON_GRADUATE.value
 
     if is_early:
         assert early_bird_deadline is not None
-        deadline_display = early_bird_deadline.strftime("%d.%m")
+        deadline_display = format_deadline_ru(early_bird_deadline)
         chunks.append(
-            templates.render(
-                event,
-                "payment_price_early",
-                {
-                    "price_label": price_label,
-                    "regular_amount": regular_amount,
-                    "deadline": deadline_display,
-                    "discount": early_bird_discount_amount,
-                    "discounted_amount": discounted_amount,
-                    "season": season,
-                },
-            ).strip()
+            _build_early_bird_payment_block(
+                city=city,
+                formula=payment_formula,
+                price_label=price_label,
+                regular_amount=regular_amount,
+                discount=early_bird_discount_amount,
+                discounted_amount=discounted_amount,
+                deadline_display=deadline_display,
+                season=season,
+                include_formula=include_formula,
+            )
         )
     else:
+        if include_formula:
+            chunks.append(
+                templates.render(
+                    event, "payment_intro", {"city": city, "formula": payment_formula}
+                ).strip()
+            )
         chunks.append(
             templates.render(
                 event,
@@ -280,8 +315,8 @@ async def _send_payment_info_messages(
             guest_msg += f"  {i}. {guest_name} — {g['price']} руб.\n"
         if is_early and total_regular_with_guests != total_discounted_with_guests:
             guest_msg += (
-                f"\n💰 Итого с гостями: {total_regular_with_guests} руб."
-                f"\n💰 <b>При ранней регистрации: {total_discounted_with_guests} руб.</b>"
+                f"\nИтоговая цена с гостями со скидкой за раннюю регистрацию:\n"
+                f"<b>{total_discounted_with_guests} руб.</b>"
             )
         else:
             guest_msg += (
@@ -463,8 +498,8 @@ async def _handle_too_expensive(
                     )
                 await send_safe(
                     message.chat.id,
-                    "Отметили интерес. Напишите @mariikors — она решает "
-                    "скидку / бесплатный вход / задачи.",
+                    "Отметили интерес. Напишите @mariikors — можно "
+                    "договориться на скидку / бесплатный вход / задачи.",
                 )
     else:
         await send_safe(
@@ -552,7 +587,23 @@ async def _handle_paid_await_proof(
         regular_amount,
         formula_amount,
         graduate_type,
+        payment_method=payment_method,
+        payment_method_source="user",
     )
+
+
+def _payment_method_label(method: str | None, *, source: str | None = None) -> str:
+    if method == "to_maria":
+        base = "Маше (перевод)"
+    elif method == "on_site":
+        base = "сайт / карта"
+    else:
+        base = "неизвестно"
+    if source == "ai":
+        return f"{base} · AI"
+    if source == "user":
+        return f"{base} · выбрал(а)"
+    return base
 
 
 def _build_user_info_text(
@@ -564,9 +615,18 @@ def _build_user_info_text(
     total_regular_with_guests: int,
     user_registration,
     graduate_type: str,
+    payment_method: str | None = None,
+    payment_method_source: str | None = None,
+    method_reason: str | None = None,
 ) -> str:
     user_info = f"👤 Пользователь: {username or ''} (ID: {user_id})\n"
     user_info += f"📍 Город: {city}\n"
+    if payment_method:
+        user_info += (
+            f"📍 Куда: {_payment_method_label(payment_method, source=payment_method_source)}\n"
+        )
+        if method_reason:
+            user_info += f"💬 {escape(method_reason)}\n"
     if guests:
         user_info += f"💰 Сумма (регистрант): {needs_to_pay}\n"
         user_info += f"👥 Гости ({len(guests)}):\n"
@@ -682,7 +742,10 @@ async def _forward_proof_to_events_chat(
     regular_amount: int,
     formula_amount: int,
     username: str,
-) -> None:
+    payment_method: str | None = None,
+    payment_method_source: str | None = None,
+) -> tuple[str | None, str | None]:
+    """Forward proof to events chat. Returns resolved (payment_method, source)."""
     logger.info(f"Starting payment proof forwarding for user {user_id}, city: {city}")
     events_chat_id = app.settings.events_chat_id
     logger.info(f"Events chat ID: {events_chat_id}")
@@ -706,17 +769,6 @@ async def _forward_proof_to_events_chat(
         else GraduateType.GRADUATE.value
     )
 
-    user_info = _build_user_info_text(
-        user_id,
-        username,
-        city,
-        guests,
-        needs_to_pay,
-        total_regular_with_guests,
-        user_registration,
-        graduate_type,
-    )
-
     from botspot.core.dependency_manager import get_dependency_manager
 
     deps = get_dependency_manager()
@@ -728,6 +780,29 @@ async def _forward_proof_to_events_chat(
         f"Parsing payment info from response: has_photo={has_photo}, has_pdf={has_pdf}"
     )
     payment_info = await parse_payment_info(response, has_photo, has_pdf, bot)
+
+    # Prefer explicit user choice; otherwise AI destination (Maria name/phone → to_maria).
+    method_reason = payment_info.method_reason
+    if payment_method in ("on_site", "to_maria"):
+        resolved_method = payment_method
+        resolved_source = payment_method_source or "user"
+    else:
+        resolved_method = payment_info.payment_method
+        resolved_source = "ai"
+
+    user_info = _build_user_info_text(
+        user_id,
+        username,
+        city,
+        guests,
+        needs_to_pay,
+        total_regular_with_guests,
+        user_registration,
+        graduate_type,
+        payment_method=resolved_method,
+        payment_method_source=resolved_source,
+        method_reason=method_reason if resolved_source == "ai" else None,
+    )
 
     logger.info(
         f"Creating validation buttons for user {user_id}, city: {city}, event_id: {event_id}"
@@ -780,10 +855,13 @@ async def _forward_proof_to_events_chat(
         screenshot_message_id=forwarded_msg.message_id,
         formula_amount=formula_amount,
         payment_status="pending",
+        payment_method=resolved_method,
+        payment_method_source=resolved_source,
     )
     logger.info(
         f"Payment proof from user {user_id} sent to validation chat with caption"
     )
+    return resolved_method, resolved_source
 
 
 async def _handle_screenshot_upload(
@@ -799,6 +877,8 @@ async def _handle_screenshot_upload(
     regular_amount: int,
     formula_amount: int,
     graduate_type: str,
+    payment_method: str | None = None,
+    payment_method_source: str | None = None,
 ) -> bool:
     has_photo = hasattr(response, "photo") and response.photo
     has_pdf = (
@@ -833,6 +913,8 @@ async def _handle_screenshot_upload(
             "amount": discounted_amount,
             "proof_type": "photo" if has_photo else "pdf",
             "graduate_type": graduate_type,
+            "payment_method": payment_method,
+            "payment_method_source": payment_method_source,
         },
         user_id,
         username,
@@ -847,6 +929,8 @@ async def _handle_screenshot_upload(
         formula_amount=formula_amount,
         username=username,
         payment_status="pending",
+        payment_method=payment_method,
+        payment_method_source=payment_method_source,
     )
 
     try:
@@ -862,6 +946,8 @@ async def _handle_screenshot_upload(
             regular_amount,
             formula_amount,
             username,
+            payment_method=payment_method,
+            payment_method_source=payment_method_source,
         )
     except Exception as e:
         logger.error(f"Error forwarding payment proof to validation chat: {e}")
@@ -1071,20 +1157,36 @@ async def parse_payment_info(
 ) -> PaymentInfo:
     from src.routers.admin import extract_payment_from_image
 
+    recipient_name = app.settings.payment_name
+    recipient_phone = app.settings.payment_phone_number
+    model = app.settings.payment_parse_model
+
     # Get the file
     if has_photo:
         file_id = response.photo[-1].file_id
         file = await bot.get_file(file_id)
         file_bytes = await bot.download_file(file.file_path)
-        return await extract_payment_from_image(file_bytes.read(), "image/jpeg")
+        return await extract_payment_from_image(
+            file_bytes.read(),
+            "image/jpeg",
+            recipient_name=recipient_name,
+            recipient_phone=recipient_phone,
+            model=model,
+        )
     elif has_pdf:
         assert response.document is not None
         file_id = response.document.file_id
         file = await bot.get_file(file_id)
         file_bytes = await bot.download_file(file.file_path)
-        return await extract_payment_from_image(file_bytes.read(), "application/pdf")
+        return await extract_payment_from_image(
+            file_bytes.read(),
+            "application/pdf",
+            recipient_name=recipient_name,
+            recipient_phone=recipient_phone,
+            model=model,
+        )
     else:
-        return PaymentInfo(amount=None, is_valid=False)
+        return PaymentInfo(amount=None, is_valid=False, paid_to_maria=False)
 
 
 # Add payment command handler

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -216,21 +216,23 @@ async def _send_payment_info_messages(
     full_name: str = "",
     graduation_year: int | str | None = None,
 ):
+    """Send payment info in two user-visible messages (price+guests, then how to pay)."""
     from botspot.core.dependency_manager import get_dependency_manager
     from src.pay_url import build_pay_url
 
     deps = get_dependency_manager()
     await deps.bot.send_chat_action(chat_id=message.chat.id, action="typing")
-    await asyncio.sleep(3)
+    await asyncio.sleep(1)
 
     payment_formula = _build_payment_formula(event)
+    chunks: list[str] = []
 
     if graduate_type != GraduateType.NON_GRADUATE.value:
-        payment_msg_part1 = templates.render(
-            event, "payment_intro", {"city": city, "formula": payment_formula}
+        chunks.append(
+            templates.render(
+                event, "payment_intro", {"city": city, "formula": payment_formula}
+            ).strip()
         )
-        await send_safe(message.chat.id, payment_msg_part1)
-        await asyncio.sleep(5)
 
     price_label = (
         "Минимальный взнос для вас"
@@ -244,33 +246,35 @@ async def _send_payment_info_messages(
     if is_early:
         assert early_bird_deadline is not None
         deadline_display = early_bird_deadline.strftime("%d.%m")
-        payment_msg_part2 = templates.render(
-            event,
-            "payment_price_early",
-            {
-                "price_label": price_label,
-                "regular_amount": regular_amount,
-                "deadline": deadline_display,
-                "discount": early_bird_discount_amount,
-                "discounted_amount": discounted_amount,
-                "season": season,
-            },
+        chunks.append(
+            templates.render(
+                event,
+                "payment_price_early",
+                {
+                    "price_label": price_label,
+                    "regular_amount": regular_amount,
+                    "deadline": deadline_display,
+                    "discount": early_bird_discount_amount,
+                    "discounted_amount": discounted_amount,
+                    "season": season,
+                },
+            ).strip()
         )
     else:
-        payment_msg_part2 = templates.render(
-            event,
-            "payment_price_regular",
-            {
-                "price_label": price_label,
-                "regular_amount": regular_amount,
-                "season": season,
-            },
+        chunks.append(
+            templates.render(
+                event,
+                "payment_price_regular",
+                {
+                    "price_label": price_label,
+                    "regular_amount": regular_amount,
+                    "season": season,
+                },
+            ).strip()
         )
 
-    await send_safe(message.chat.id, payment_msg_part2)
-
     if guests:
-        guest_msg = f"\n👥 Гости ({len(guests)}):\n"
+        guest_msg = f"👥 Гости ({len(guests)}):\n"
         for i, g in enumerate(guests, 1):
             guest_name = escape(str(g["name"]), quote=True)
             guest_msg += f"  {i}. {guest_name} — {g['price']} руб.\n"
@@ -283,10 +287,10 @@ async def _send_payment_info_messages(
             guest_msg += (
                 f"\n💰 <b>Итого с гостями: {total_regular_with_guests} руб.</b>"
             )
-        await send_safe(message.chat.id, guest_msg)
-        await asyncio.sleep(2)
+        chunks.append(guest_msg.strip())
 
-    await asyncio.sleep(3)
+    await send_safe(message.chat.id, "\n\n".join(chunks))
+    await asyncio.sleep(1)
 
     # Same total the user is told to pay (early-bird + guests when applicable).
     pay_amount = total_discounted_with_guests if is_early else total_regular_with_guests
@@ -306,7 +310,7 @@ async def _send_payment_info_messages(
         },
     )
     await send_safe(message.chat.id, payment_msg_part3)
-    await asyncio.sleep(3)
+    await asyncio.sleep(1)
 
 
 async def _handle_pay_later(
@@ -319,10 +323,16 @@ async def _handle_pay_later(
     regular_amount: int,
     formula_amount: int,
     graduate_type: str,
+    event: dict | None = None,
 ):
+    from src.payment_timeline import pay_later_message
+
+    if event is None:
+        event = await app.get_event_by_id(event_id) or {}
+
     await send_safe(
         message.chat.id,
-        "Хорошо! Вы можете оплатить позже, используя команду /pay",
+        pay_later_message(event),
         reply_markup=ReplyKeyboardRemove(),
     )
     await app.log_registration_step(
@@ -346,7 +356,25 @@ async def _handle_pay_later(
         discounted_amount=discounted_amount,
         regular_amount=regular_amount,
         formula_amount=formula_amount,
+        payment_status="not paid",
     )
+    # Mark for reminder job (not yet reminded).
+    try:
+        coll = app.collection
+        update = coll.update_one(
+            {"user_id": user_id, "event_id": event_id},
+            {
+                "$set": {
+                    "pay_later_selected": True,
+                    "payment_reminder_d4_sent": False,
+                    "payment_reminder_d2_sent": False,
+                }
+            },
+        )
+        if hasattr(update, "__await__"):
+            await update
+    except Exception as e:
+        logger.warning(f"Could not set pay_later flags for {user_id}: {e}")
 
 
 async def _handle_too_expensive(
@@ -358,7 +386,10 @@ async def _handle_too_expensive(
     discounted_amount: int,
     regular_amount: int,
     graduate_type: str,
+    state: FSMContext | None = None,
 ):
+    from src.payment_timeline import too_expensive_cancel_message
+
     await app.log_registration_step(
         user_id=user_id,
         username=username,
@@ -384,13 +415,55 @@ async def _handle_too_expensive(
 
     if registration:
         full_name = registration.get("full_name", "Unknown")
-        await app.delete_user_registration(user_id, event_id)
+        # Soft-delete keeps the row in deleted_users so /start can reuse profile.
+        await app.delete_user_registration(
+            user_id, event_id, username=username, full_name=full_name
+        )
         await app.log_registration_canceled(user_id, username, full_name, city)
         await send_safe(
             message.chat.id,
-            "Понимаем! Ваша регистрация отменена. Если передумаете, вы всегда можете зарегистрироваться снова с помощью команды /start",
+            too_expensive_cancel_message(),
             reply_markup=ReplyKeyboardRemove(),
         )
+        if state is not None:
+            interest = await ask_user_choice(
+                message.chat.id,
+                "Хотите, чтобы мы отметили интерес к волонтёрству "
+                "(Мария @mariikors свяжется / учтёт)?",
+                choices={
+                    "volunteer_yes": "Да, интересно волонтёрство",
+                    "volunteer_no": "Нет, спасибо",
+                },
+                state=state,
+                timeout=300,
+            )
+            if interest == "volunteer_yes":
+                await app.save_event_log(
+                    "payment_action",
+                    {
+                        "action": "volunteer_interest_after_too_expensive",
+                        "city": city,
+                        "full_name": full_name,
+                        "amount": discounted_amount,
+                    },
+                    user_id,
+                    username,
+                )
+                try:
+                    await app.log_to_chat(
+                        f"🙋 Волонтёрский интерес (после «дорого»)\n"
+                        f"{full_name} (@{username or '—'})\n"
+                        f"user_id={user_id} · {city} · взнос был {discounted_amount}₽\n"
+                        f"→ @mariikors",
+                        "events",
+                    )
+                except Exception as e:
+                    logger.warning(f"Could not log volunteer interest to events chat: {e}")
+                await send_safe(
+                    message.chat.id,
+                    "Отметили интерес. Напишите @mariikors — она решает "
+                    "скидку / бесплатный вход / задачи.",
+                )
     else:
         await send_safe(
             message.chat.id,
@@ -733,9 +806,12 @@ async def _handle_screenshot_upload(
     )
 
     if not (has_photo or has_pdf):
+        from src.payment_timeline import pay_later_message
+
+        event = await app.get_event_by_id(event_id) or {}
         await send_safe(
             message.chat.id,
-            "Хорошо! Вы можете оплатить позже, используя команду /pay",
+            pay_later_message(event),
             reply_markup=ReplyKeyboardRemove(),
         )
         await app.save_payment_info(
@@ -743,6 +819,7 @@ async def _handle_screenshot_upload(
             event_id=event_id,
             discounted_amount=discounted_amount,
             regular_amount=regular_amount,
+            payment_status="not paid",
         )
         return False
 
@@ -953,6 +1030,7 @@ async def process_payment(
                 regular_amount,
                 formula_amount,
                 graduate_type,
+                event=event,
             )
             return False
         if response == "too_expensive":
@@ -965,6 +1043,7 @@ async def process_payment(
                 discounted_amount,
                 regular_amount,
                 graduate_type,
+                state=state,
             )
             return False
 

--- a/src/templates.py
+++ b/src/templates.py
@@ -169,40 +169,31 @@ class _HtmlChecker(HTMLParser):
         return self
 
 
-def validate_template(spec: TemplateSpec, text: str) -> List[str]:
-    """Admin-facing reasons the text is unusable. Empty list means it's fine."""
-    errors: List[str] = []
-
-    if not text.strip():
-        errors.append("Текст не может быть пустым.")
-        return errors
-
+def _validate_placeholders(spec: TemplateSpec, text: str, errors: List[str]) -> None:
     used = set(PLACEHOLDER_RE.findall(text))
     unknown = used - spec.placeholders
     if unknown:
         allowed = ", ".join("{" + p + "}" for p in sorted(spec.placeholders))
         got = ", ".join("{" + p + "}" for p in sorted(unknown))
         errors.append(f"Неизвестные подстановки: {got}. Доступны: {allowed}")
-
     missing = spec.placeholders - used
     if missing:
         required = ", ".join("{" + p + "}" for p in sorted(missing))
         errors.append(f"Обязательные подстановки пропущены: {required}")
-
-    # A lone "{" or "}" that isn't part of a placeholder is almost always a typo
-    # that would silently ship to users as a stray brace.
+    # Lone braces that aren't placeholders are almost always typos.
     without = PLACEHOLDER_RE.sub("", text)
     if "{" in without or "}" in without:
         errors.append("Непарная скобка { или }. Подстановки пишутся как {name}.")
 
+
+def _validate_html_markup(text: str, errors: List[str]) -> None:
     checker = _HtmlChecker()
     try:
         checker.feed(text)
         checker.finish()
     except Exception as e:  # pragma: no cover - HTMLParser is lenient
         errors.append(f"Не удалось разобрать HTML: {e}")
-        return errors
-
+        return
     if checker.bad_tags:
         tags = ", ".join(sorted(set(checker.bad_tags)))
         errors.append(
@@ -224,6 +215,14 @@ def validate_template(spec: TemplateSpec, text: str) -> List[str]:
     if checker.stray_close:
         errors.append(f"Лишние закрывающие теги: {', '.join(checker.stray_close)}")
 
+
+def validate_template(spec: TemplateSpec, text: str) -> List[str]:
+    """Admin-facing reasons the text is unusable. Empty list means it's fine."""
+    if not text.strip():
+        return ["Текст не может быть пустым."]
+    errors: List[str] = []
+    _validate_placeholders(spec, text, errors)
+    _validate_html_markup(text, errors)
     return errors
 
 

--- a/src/ticket_cards.py
+++ b/src/ticket_cards.py
@@ -1,0 +1,365 @@
+"""Deterministic personalized entry cards for confirmed registrations."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import re
+from datetime import date, datetime
+from functools import lru_cache
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Mapping
+
+from aiogram.types import BufferedInputFile
+from PIL import Image, ImageDraw, ImageFont
+from pydantic import BaseModel, Field
+
+from botspot.core.dependency_manager import get_dependency_manager
+from botspot.utils.internal import get_logger
+
+
+logger = get_logger()
+
+CARD_SIZE = (1200, 760)
+_TICKET_CODE_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9-]{7,39}$")
+
+
+class TicketCardError(ValueError):
+    """Raised when a registration must not receive an entry card."""
+
+
+class TicketCardData(BaseModel):
+    """Validated display data; no payment-provider secrets are rendered."""
+
+    full_name: str = Field(min_length=1, max_length=160)
+    graduate_label: str = Field(min_length=1, max_length=80)
+    event_name: str = Field(min_length=1, max_length=160)
+    event_date: str = Field(min_length=1, max_length=80)
+    event_time: str = Field(min_length=1, max_length=40)
+    venue: str = Field(min_length=1, max_length=160)
+    address: str = Field(min_length=1, max_length=240)
+    guest_names: list[str] = Field(default_factory=list, max_length=3)
+    ticket_code: str = Field(pattern=_TICKET_CODE_PATTERN.pattern)
+
+
+class TicketCardArtifact(BaseModel):
+    """Telegram-ready deterministic PNG plus its user-facing metadata."""
+
+    image: bytes
+    filename: str
+    caption: str
+    ticket_code: str
+
+
+def is_ticket_unlocked(registration: Mapping[str, Any]) -> bool:
+    """The current bot contract: only exact confirmed status unlocks entry."""
+
+    return registration.get("payment_status") == "confirmed"
+
+
+def _clean_text(value: Any, default: str, max_length: int) -> str:
+    text = " ".join(str(value or "").split())
+    return (text or default)[:max_length]
+
+
+def _object_id(value: Any, field: str) -> str:
+    text = _clean_text(value, "", 160)
+    if not text:
+        raise TicketCardError(f"Missing {field}")
+    return text
+
+
+def _event_date_display(event: Mapping[str, Any]) -> str:
+    displayed = _clean_text(event.get("date_display"), "", 80)
+    if displayed:
+        return displayed
+
+    value = event.get("date")
+    if isinstance(value, datetime | date):
+        return value.strftime("%d.%m.%Y")
+    return "Дата уточняется"
+
+
+def _graduate_label(registration: Mapping[str, Any]) -> str:
+    graduate_type = registration.get("graduate_type", "GRADUATE")
+    if graduate_type == "TEACHER":
+        return "Учитель"
+    if graduate_type == "ORGANIZER":
+        return "Организатор"
+    if graduate_type == "NON_GRADUATE":
+        return "Друг школы"
+
+    year = _clean_text(registration.get("graduation_year"), "", 8)
+    class_letter = _clean_text(registration.get("class_letter"), "", 12)
+    if year and class_letter:
+        return f"Выпуск {year} • класс {class_letter}"
+    if year:
+        return f"Выпуск {year}"
+    return "Выпускник школы 146"
+
+
+def _guest_names(registration: Mapping[str, Any]) -> list[str]:
+    raw_guests = registration.get("guests") or []
+    if not isinstance(raw_guests, list):
+        raise TicketCardError("Registration guests must be a list")
+    if len(raw_guests) > 3:
+        raise TicketCardError("Entry card supports at most three registered guests")
+
+    names: list[str] = []
+    for guest in raw_guests:
+        if not isinstance(guest, Mapping):
+            raise TicketCardError("Each guest must be a named registration record")
+        name = _clean_text(guest.get("name"), "", 80)
+        if not name:
+            raise TicketCardError("Each guest must have a name")
+        names.append(name)
+    return names
+
+
+def _ticket_code(registration: Mapping[str, Any], event_id: str) -> str:
+    """Use a future website code when present; otherwise make a stable visual ID.
+
+    The derived fallback is deliberately only a visual registration reference,
+    not a cryptographic proof. A website-issued opaque code can be written to
+    ``ticket_code`` later without changing rendering or `/status` delivery.
+    """
+
+    explicit = registration.get("ticket_code")
+    if explicit is not None:
+        code = _clean_text(explicit, "", 40)
+        if not _TICKET_CODE_PATTERN.fullmatch(code):
+            raise TicketCardError("Invalid website-issued ticket_code")
+        return code
+
+    registration_id = _object_id(registration.get("_id"), "registration _id")
+    user_id = _object_id(registration.get("user_id"), "Telegram user_id")
+    payload = f"ticket-card-v1|{registration_id}|{event_id}|{user_id}".encode()
+    digest = hashlib.sha256(payload).hexdigest().upper()[:12]
+    return f"146-{digest[:4]}-{digest[4:8]}-{digest[8:]}"
+
+
+def build_ticket_card_data(
+    registration: Mapping[str, Any], event: Mapping[str, Any] | None
+) -> TicketCardData:
+    """Build a card only when registration, person, and event bindings agree."""
+
+    if not is_ticket_unlocked(registration):
+        raise TicketCardError("Entry card requires payment_status == confirmed")
+    if event is None:
+        raise TicketCardError("Entry card requires an event")
+
+    registration_event_id = _object_id(registration.get("event_id"), "event_id")
+    event_id = _object_id(event.get("_id"), "event _id")
+    if registration_event_id != event_id:
+        raise TicketCardError("Registration event_id does not match the event")
+
+    return TicketCardData(
+        full_name=_clean_text(registration.get("full_name"), "", 160),
+        graduate_label=_graduate_label(registration),
+        event_name=_clean_text(
+            event.get("name") or event.get("title"), "Мероприятие клуба 146", 160
+        ),
+        event_date=_event_date_display(event),
+        event_time=_clean_text(event.get("time_display"), "Время уточняется", 40),
+        venue=_clean_text(event.get("venue"), "Место уточняется", 160),
+        address=_clean_text(event.get("address"), "Адрес уточняется", 240),
+        guest_names=_guest_names(registration),
+        ticket_code=_ticket_code(registration, event_id),
+    )
+
+
+@lru_cache(maxsize=2)
+def _font_path(bold: bool) -> Path:
+    """Use Matplotlib's bundled DejaVu font on every deployment platform."""
+
+    spec = importlib.util.find_spec("matplotlib")
+    if spec is None or not spec.submodule_search_locations:
+        raise TicketCardError("Matplotlib's bundled ticket font is unavailable")
+    filename = "DejaVuSans-Bold.ttf" if bold else "DejaVuSans.ttf"
+    path = (
+        Path(next(iter(spec.submodule_search_locations)))
+        / "mpl-data/fonts/ttf"
+        / filename
+    )
+    if not path.is_file():
+        raise TicketCardError("Matplotlib's bundled ticket font is unavailable")
+    return path
+
+
+@lru_cache(maxsize=64)
+def _font(size: int, *, bold: bool = False) -> ImageFont.FreeTypeFont:
+    return ImageFont.truetype(_font_path(bold), size=size)
+
+
+def _fit_font(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    max_width: int,
+    preferred_size: int,
+    minimum_size: int,
+):
+    for size in range(preferred_size, minimum_size - 1, -2):
+        font = _font(size)
+        box = draw.textbbox((0, 0), text, font=font)
+        if box[2] - box[0] <= max_width:
+            return font
+    return _font(minimum_size)
+
+
+def _ellipsize(draw: ImageDraw.ImageDraw, text: str, font, max_width: int) -> str:
+    if draw.textbbox((0, 0), text, font=font)[2] <= max_width:
+        return text
+    shortened = text
+    while shortened:
+        candidate = shortened.rstrip() + "…"
+        if draw.textbbox((0, 0), candidate, font=font)[2] <= max_width:
+            return candidate
+        shortened = shortened[:-1]
+    return "…"
+
+
+def _wrap_lines(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    font,
+    max_width: int,
+    max_lines: int,
+) -> list[str]:
+    words = text.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if not current or draw.textbbox((0, 0), candidate, font=font)[2] <= max_width:
+            current = candidate
+            continue
+        lines.append(_ellipsize(draw, current, font, max_width))
+        current = word
+        if len(lines) == max_lines - 1:
+            break
+    if current and len(lines) < max_lines:
+        remaining_start = len(" ".join(lines + [current]).split())
+        remaining = " ".join(words[remaining_start:])
+        final = f"{current} {remaining}".strip()
+        lines.append(_ellipsize(draw, final, font, max_width))
+    return lines or [""]
+
+
+def render_ticket_card(data: TicketCardData) -> bytes:
+    """Render the same validated input to byte-identical PNG output."""
+
+    image = Image.new("RGB", CARD_SIZE, "#0B2433")
+    draw = ImageDraw.Draw(image)
+
+    draw.rounded_rectangle((28, 28, 1172, 732), radius=34, fill="#F7F2E8")
+    draw.rounded_rectangle((28, 28, 1172, 124), radius=34, fill="#143F56")
+    draw.rectangle((28, 88, 1172, 124), fill="#143F56")
+    draw.text(
+        (68, 57),
+        "КЛУБ ДРУЗЕЙ ШКОЛЫ 146",
+        font=_font(34, bold=True),
+        fill="#FFFFFF",
+    )
+    draw.rounded_rectangle((969, 49, 1125, 103), radius=18, fill="#F0AA36")
+    draw.text((1011, 62), "ВХОД", font=_font(25, bold=True), fill="#152A35")
+
+    draw.text(
+        (68, 154),
+        "ИМЕННОЙ БИЛЕТ • БЕЙДЖ",
+        font=_font(30, bold=True),
+        fill="#B46B14",
+    )
+    name_font = _fit_font(draw, data.full_name, 1060, 68, 38)
+    name = _ellipsize(draw, data.full_name, name_font, 1060)
+    draw.text((68, 210), name, font=name_font, fill="#102E3D")
+    draw.text((71, 302), data.graduate_label, font=_font(30), fill="#4E6671")
+
+    details_top = 365
+    if data.guest_names:
+        guests = f"С вами: {', '.join(data.guest_names)}"
+        guests_font = _fit_font(draw, guests, 1060, 24, 19)
+        guests = _ellipsize(draw, guests, guests_font, 1060)
+        draw.text((71, 342), guests, font=guests_font, fill="#4E6671")
+        details_top = 390
+
+    draw.line((68, details_top, 1132, details_top), fill="#C8D1D2", width=3)
+    event_font = _fit_font(draw, data.event_name, 1060, 40, 28)
+    event_name = _ellipsize(draw, data.event_name, event_font, 1060)
+    draw.text((68, details_top + 32), event_name, font=event_font, fill="#102E3D")
+    draw.text(
+        (68, details_top + 97),
+        f"{data.event_date} • {data.event_time}",
+        font=_font(30),
+        fill="#143F56",
+    )
+
+    details_font = _font(25)
+    place = f"{data.venue} • {data.address}"
+    for index, line in enumerate(
+        _wrap_lines(draw, place, details_font, 1060, max_lines=2)
+    ):
+        draw.text(
+            (68, details_top + 151 + index * 38),
+            line,
+            font=details_font,
+            fill="#4E6671",
+        )
+
+    draw.rounded_rectangle((68, 636, 570, 698), radius=18, fill="#DCE8E4")
+    draw.text(
+        (91, 650),
+        "ОПЛАТА ПОДТВЕРЖДЕНА",
+        font=_font(26, bold=True),
+        fill="#176747",
+    )
+    code_label = f"КОД: {data.ticket_code}"
+    code_font = _fit_font(draw, code_label, 510, 27, 20)
+    draw.text((622, 652), code_label, font=code_font, fill="#143F56")
+
+    output = BytesIO()
+    image.save(output, format="PNG", optimize=False, compress_level=9)
+    return output.getvalue()
+
+
+def make_ticket_card(
+    registration: Mapping[str, Any], event: Mapping[str, Any] | None
+) -> TicketCardArtifact:
+    """Build the Telegram artifact after enforcing the confirmed-payment gate."""
+
+    data = build_ticket_card_data(registration, event)
+    return TicketCardArtifact(
+        image=render_ticket_card(data),
+        filename=f"club-146-ticket-{data.ticket_code}.png",
+        caption=(
+            "🎟 Ваш именной билет и бейдж. "
+            "Покажите эту карточку на входе.\n"
+            f"Код: {data.ticket_code}"
+        ),
+        ticket_code=data.ticket_code,
+    )
+
+
+async def send_paid_ticket_card(
+    chat_id: int,
+    registration: Mapping[str, Any],
+    event: Mapping[str, Any] | None,
+) -> bool:
+    """Send a confirmed card; unpaid/invalid data fails closed without a send."""
+
+    if not is_ticket_unlocked(registration):
+        return False
+
+    try:
+        artifact = make_ticket_card(registration, event)
+        bot = get_dependency_manager().bot
+        await bot.send_photo(
+            chat_id=chat_id,
+            photo=BufferedInputFile(artifact.image, filename=artifact.filename),
+            caption=artifact.caption,
+            parse_mode=None,
+        )
+    except Exception as exc:
+        logger.warning(f"Could not send paid ticket card: {exc}")
+        return False
+    return True

--- a/src/user_interactions.py
+++ b/src/user_interactions.py
@@ -97,6 +97,36 @@ class UserInputManager:
 input_manager = UserInputManager()
 
 
+async def _cleanup_prompt_messages(
+    sent_message: Message,
+    request: "PendingRequest",
+    *,
+    cleanup: bool,
+) -> None:
+    if cleanup:
+        await sent_message.delete()
+        if request.raw_response:
+            await request.raw_response.delete()
+    elif sent_message.reply_markup:
+        await sent_message.edit_text(text=sent_message.text or "", reply_markup=None)
+
+
+async def _handle_ask_timeout(
+    sent_message: Message,
+    question: str,
+    *,
+    notify_on_timeout: bool,
+    default_choice: Optional[str],
+) -> Optional[str]:
+    if notify_on_timeout:
+        if default_choice is not None:
+            question += f"\n\n⏰ Auto-selected: {default_choice}"
+        else:
+            question += "\n\n⏰ No response received within the time limit."
+        await sent_message.edit_text(question)
+    return default_choice
+
+
 async def _ask_user_base(
     chat_id: int,
     question: str,
@@ -115,18 +145,15 @@ async def _ask_user_base(
 
     if not question or question.strip() == "":
         raise ValueError("Message text cannot be empty")
-
-    deps = get_dependency_manager()
-    bot: Bot = deps.bot
-
-    handler_id = f"ask_{datetime.now().timestamp()}"
-
     if default_choice is not None and return_raw:
         raise ValueError("Cannot return default choice when return_raw is True")
 
+    deps = get_dependency_manager()
+    bot: Bot = deps.bot
+    handler_id = f"ask_{datetime.now().timestamp()}"
+
     await state.set_state(UserInputState.waiting)
     await state.update_data(handler_id=handler_id)
-
     request = input_manager.add_request(
         chat_id,
         handler_id,
@@ -148,28 +175,17 @@ async def _ask_user_base(
 
     try:
         await asyncio.wait_for(request.event.wait(), timeout=timeout)
-        if cleanup:
-            await sent_message.delete()
-            if request.raw_response:
-                await request.raw_response.delete()
-        elif sent_message.reply_markup:
-            await sent_message.edit_text(
-                text=sent_message.text or "", reply_markup=None
-            )
-
-        return (
-            request.raw_response
-            if (return_raw and request.raw_response is not None)
-            else request.response
-        )
+        await _cleanup_prompt_messages(sent_message, request, cleanup=cleanup)
+        if return_raw and request.raw_response is not None:
+            return request.raw_response
+        return request.response
     except asyncio.TimeoutError:
-        if notify_on_timeout:
-            if default_choice is not None:
-                question += f"\n\n⏰ Auto-selected: {default_choice}"
-            else:
-                question += "\n\n⏰ No response received within the time limit."
-            await sent_message.edit_text(question)
-        return default_choice
+        return await _handle_ask_timeout(
+            sent_message,
+            question,
+            notify_on_timeout=notify_on_timeout,
+            default_choice=default_choice,
+        )
     finally:
         input_manager.remove_request(chat_id, handler_id)
         await state.clear()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -363,6 +363,57 @@ async def test_admin_register_payment_select_user_and_confirm(
 
 
 @pytest.mark.asyncio
+async def test_admin_register_payment_rereads_and_sends_confirmed_ticket(
+    mock_message, mock_state, mock_app, mock_send_safe
+):
+    """The separate admin flow sends the ticket from authoritative updated state."""
+
+    event = _make_event()
+    event_id = str(event["_id"])
+    unpaid = _make_unpaid_user(user_id=111, username="alice", full_name="Алиса")
+    confirmed = {
+        **unpaid,
+        "event_id": event_id,
+        "payment_status": "confirmed",
+        "payment_amount": 2000,
+    }
+    mock_app.get_all_events.return_value = [event]
+    mock_app.get_unpaid_users.return_value = [unpaid]
+    mock_app.collection.find_one.return_value = confirmed
+    mock_app.get_event_for_registration.return_value = event
+
+    choices = iter([event_id, "111"])
+
+    async def choose(*args, **kwargs):
+        return next(choices)
+
+    with (
+        patch(
+            "src.routers.admin.ask_user_choice",
+            new_callable=AsyncMock,
+            side_effect=choose,
+        ),
+        patch(
+            "src.routers.admin.ask_user_raw",
+            new_callable=AsyncMock,
+            return_value="2000",
+        ),
+        patch("botspot.core.dependency_manager.get_dependency_manager") as mock_deps,
+        patch(
+            "src.routers.admin.send_paid_ticket_card", new_callable=AsyncMock
+        ) as send_ticket,
+    ):
+        mock_deps.return_value.bot = AsyncMock()
+        await admin_register_payment(mock_message, mock_state, mock_app)
+
+    mock_app.collection.find_one.assert_awaited_once_with(
+        {"user_id": 111, "event_id": event_id}
+    )
+    mock_app.get_event_for_registration.assert_awaited_once_with(confirmed)
+    send_ticket.assert_awaited_once_with(111, confirmed, event)
+
+
+@pytest.mark.asyncio
 async def test_admin_register_payment_manual_username_found(
     mock_message, mock_state, mock_app, mock_send_safe
 ):
@@ -416,7 +467,7 @@ async def test_admin_register_payment_manual_username_found(
         await admin_register_payment(mock_message, mock_state, mock_app)
 
     # Verify find_one called with stripped username
-    mock_app.collection.find_one.assert_called_once_with(
+    mock_app.collection.find_one.assert_any_await(
         {"username": "vasya", "event_id": eid}
     )
     mock_app.update_payment_status.assert_called_once_with(
@@ -752,7 +803,7 @@ async def test_admin_register_payment_manual_without_at_sign(
         mock_deps.return_value.bot = mock_bot
         await admin_register_payment(mock_message, mock_state, mock_app)
 
-    mock_app.collection.find_one.assert_called_once_with(
+    mock_app.collection.find_one.assert_any_await(
         {"username": "petya", "event_id": eid}
     )
     mock_app.update_payment_status.assert_called_once()

--- a/tests/test_app_async.py
+++ b/tests/test_app_async.py
@@ -110,7 +110,8 @@ class TestGetUserRegistrations:
 
     @pytest.mark.asyncio
     async def test_get_registration_single(self, app):
-        mock_cursor = AsyncMock()
+        mock_cursor = MagicMock()
+        mock_cursor.sort = MagicMock(return_value=mock_cursor)
         mock_cursor.to_list = AsyncMock(
             return_value=[{"user_id": 123, "target_city": "Москва"}]
         )
@@ -121,8 +122,23 @@ class TestGetUserRegistrations:
         assert result["user_id"] == 123
 
     @pytest.mark.asyncio
+    async def test_get_registration_returns_newest_row(self, app):
+        """Newest registration wins so old seasons don't leak stale data."""
+        mock_cursor = MagicMock()
+        mock_cursor.sort = MagicMock(return_value=mock_cursor)
+        mock_cursor.to_list = AsyncMock(
+            return_value=[{"user_id": 123, "target_city": "Пермь", "_id": "new"}]
+        )
+        app.collection.find = MagicMock(return_value=mock_cursor)
+
+        result = await app.get_user_registration(123)
+        assert result["_id"] == "new"
+        mock_cursor.sort.assert_called_once_with("_id", -1)
+
+    @pytest.mark.asyncio
     async def test_get_registration_none(self, app):
-        mock_cursor = AsyncMock()
+        mock_cursor = MagicMock()
+        mock_cursor.sort = MagicMock(return_value=mock_cursor)
         mock_cursor.to_list = AsyncMock(return_value=[])
         app.collection.find = MagicMock(return_value=mock_cursor)
 

--- a/tests/test_app_registration.py
+++ b/tests/test_app_registration.py
@@ -191,37 +191,36 @@ class TestAppRegistration:
             }
         ]
 
-        # Use patch to mock the get_user_registrations method
-        with patch.object(
-            self.app,
-            "get_user_registrations",
-            AsyncMock(return_value=sample_registrations),
-        ):
-            # Call the method
-            registration = await self.app.get_user_registration(123456)
+        # Mock find to return a cursor sorted newest-first
+        mock_cursor = MagicMock()
+        mock_cursor.sort = MagicMock(return_value=mock_cursor)
+        mock_cursor.to_list = AsyncMock(return_value=sample_registrations)
+        self.mock_collection.find = MagicMock(return_value=mock_cursor)
 
-            # Verify the method was called with correct parameters
-            self.app.get_user_registrations.assert_called_once_with(123456)
+        # Call the method
+        registration = await self.app.get_user_registration(123456)
 
-            # Verify the result
-            assert registration is not None
-            assert registration["target_city"] == "Москва"
+        # Verify the query and newest-first sort
+        self.mock_collection.find.assert_called_once_with({"user_id": 123456})
+        mock_cursor.sort.assert_called_once_with("_id", -1)
+
+        # Verify the result
+        assert registration is not None
+        assert registration["target_city"] == "Москва"
 
     @pytest.mark.asyncio
     async def test_get_user_registration_not_exists(self):
         """Test getting a single registration when user has no registrations"""
-        # Mock get_user_registrations to return empty list
-        with patch.object(
-            self.app, "get_user_registrations", AsyncMock(return_value=[])
-        ):
-            # Call the method
-            registration = await self.app.get_user_registration(123456)
+        mock_cursor = MagicMock()
+        mock_cursor.sort = MagicMock(return_value=mock_cursor)
+        mock_cursor.to_list = AsyncMock(return_value=[])
+        self.mock_collection.find = MagicMock(return_value=mock_cursor)
 
-            # Verify the method was called with correct parameters
-            self.app.get_user_registrations.assert_called_once_with(123456)
+        # Call the method
+        registration = await self.app.get_user_registration(123456)
 
-            # Verify the result
-            assert registration is None
+        # Verify the result
+        assert registration is None
 
     @pytest.mark.asyncio
     async def test_delete_user_registration_specific_event(self):

--- a/tests/test_crm_recipients.py
+++ b/tests/test_crm_recipients.py
@@ -97,6 +97,45 @@ async def test_current_season_announcement_queries_only_enabled_events():
     )
 
 
+@pytest.mark.asyncio
+async def test_all_time_city_audience_reaches_historical_rows():
+    """Perm recovery: history rows whose target_city embeds the city name
+    ("Пермь (Летняя встреча 2025)") or that only link via an archived Perm
+    event must be included, from both active and deleted collections."""
+    app = MagicMock()
+    app.get_all_events = AsyncMock(
+        return_value=[
+            {"_id": "perm-2026", "city": "Пермь"},
+            {"_id": "perm-summer-2025", "city": "Пермь"},
+            {"_id": "moscow-2026", "city": "Москва"},
+        ]
+    )
+    captured = {}
+
+    async def collection_distinct(field, query):
+        captured["active"] = query
+        return [1, 2]
+
+    async def deleted_distinct(field, query):
+        captured["deleted"] = query
+        return [2, 3]
+
+    app.collection.distinct = AsyncMock(side_effect=collection_distinct)
+    app.deleted_users.distinct = AsyncMock(side_effect=deleted_distinct)
+    event_map = {"perm-2026": {"city": "Пермь"}}
+
+    recipients = await _build_recipient_list(app, "all_time", "perm-2026", event_map)
+
+    assert sorted(recipients) == [1, 2, 3]
+    for query in (captured["active"], captured["deleted"]):
+        event_clause, city_clause = query["$or"]
+        assert set(event_clause["event_id"]["$in"]) == {
+            "perm-2026",
+            "perm-summer-2025",
+        }
+        assert city_clause["target_city"]["$regex"] == "^Пермь"
+
+
 @pytest.mark.parametrize(
     ("audience", "method_name"),
     [

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -386,44 +386,82 @@ def test_check_early_bird_no_event():
     assert discount == 0
 
 
-def test_check_early_bird_no_deadline():
+def test_check_early_bird_no_event_date():
+    """Discount without event date → no food/early-bird cutoff."""
     from src.routers.payment import _check_early_bird
 
     event = {"early_bird_discount": 200}
     is_early, deadline, discount = _check_early_bird(event)
     assert is_early is False
+    assert deadline is None
 
 
-def test_check_early_bird_active(monkeypatch):
-    from src.routers.payment import _check_early_bird
+def test_check_early_bird_active():
     from datetime import datetime
 
-    future_date = datetime(2099, 12, 31)
-    event = {"early_bird_deadline": future_date, "early_bird_discount": 300}
+    from src.payment_timeline import food_deadline
+    from src.routers.payment import _check_early_bird
+
+    # Early bird follows food deadline (D-4 06:00), not a separate field.
+    event = {
+        "date": datetime(2099, 12, 31),
+        "early_bird_discount": 300,
+        "early_bird_deadline": datetime(2000, 1, 1),  # ignored for timing
+    }
     is_early, deadline, discount = _check_early_bird(event)
     assert is_early is True
-    assert deadline == future_date
+    assert deadline == food_deadline(event)
     assert discount == 300
 
 
 def test_check_early_bird_expired():
-    from src.routers.payment import _check_early_bird
     from datetime import datetime
 
-    past_date = datetime(2000, 1, 1)
-    event = {"early_bird_deadline": past_date, "early_bird_discount": 300}
+    from src.routers.payment import _check_early_bird
+
+    event = {
+        "date": datetime(2000, 1, 10),
+        "early_bird_discount": 300,
+        "early_bird_deadline": datetime(2099, 1, 1),  # ignored
+    }
     is_early, deadline, discount = _check_early_bird(event)
     assert is_early is False
 
 
 def test_check_early_bird_zero_discount():
-    from src.routers.payment import _check_early_bird
     from datetime import datetime
 
-    future_date = datetime(2099, 12, 31)
-    event = {"early_bird_deadline": future_date, "early_bird_discount": 0}
+    from src.routers.payment import _check_early_bird
+
+    event = {
+        "date": datetime(2099, 12, 31),
+        "early_bird_discount": 0,
+    }
     is_early, deadline, discount = _check_early_bird(event)
     assert is_early is False
+
+
+def test_build_early_bird_payment_block_has_quote_and_final_price():
+    from src.routers.payment import _build_early_bird_payment_block
+
+    text = _build_early_bird_payment_block(
+        city="Пермь",
+        formula="1500р + 100 × (2026 − год выпуска)",
+        price_label="Минимальный взнос для вашего года выпуска",
+        regular_amount=2000,
+        discount=500,
+        discounted_amount=1500,
+        deadline_display="28.07.2026 в 06:00",
+        season="летней",
+        include_formula=True,
+    )
+    assert "<blockquote expandable>" in text
+    assert "расчет оплаты" in text
+    assert "2000 руб." in text
+    assert "скидка 500" in text
+    assert "Итоговая цена со скидкой за раннюю регистрацию" in text
+    assert "<b>1500 руб.</b>" in text
+    assert text.index("<blockquote") < text.index("Итоговая цена")
 
 
 # ---- Tests for _calc_guest_totals ----
@@ -770,7 +808,11 @@ async def test_screenshot_upload_persists_pending_with_forwarded_message_id(
 
     with patch(
         "src.routers.payment.parse_payment_info",
-        new=AsyncMock(return_value=PaymentInfo(amount=1800, is_valid=True)),
+        new=AsyncMock(
+            return_value=PaymentInfo(
+                amount=1800, is_valid=True, paid_to_maria=False, method_reason="card"
+            )
+        ),
     ):
         result = await _handle_screenshot_upload(
             mock_message,
@@ -794,6 +836,84 @@ async def test_screenshot_upload_persists_pending_with_forwarded_message_id(
     assert source_save.kwargs["screenshot_message_id"] == 777
     assert forwarded_save.kwargs["payment_status"] == "pending"
     assert forwarded_save.kwargs["screenshot_message_id"] == 888
+    # Direct upload (no button) → AI destination
+    assert forwarded_save.kwargs["payment_method"] == "on_site"
+    assert forwarded_save.kwargs["payment_method_source"] == "ai"
+    caption = bot.send_photo.await_args.kwargs["caption"]
+    assert "сайт" in caption.lower() or "карта" in caption.lower()
+
+
+@pytest.mark.asyncio
+async def test_screenshot_upload_ai_detects_maria(
+    mock_message,
+    mock_app,
+    mock_send_safe,
+    _mock_botspot_dependencies,
+):
+    from src.app import GraduateType
+    from src.routers.admin import PaymentInfo
+    from src.routers.payment import _handle_screenshot_upload
+
+    response = MagicMock(spec=Message)
+    response.photo = [MagicMock(file_id="proof-photo")]
+    response.document = None
+    response.message_id = 101
+    mock_app.collection.find_one.return_value = {
+        "full_name": "Тест",
+        "graduate_type": GraduateType.GRADUATE.value,
+    }
+    bot = _mock_botspot_dependencies.return_value.bot
+    bot.send_photo = AsyncMock(return_value=MagicMock(message_id=202))
+
+    with patch(
+        "src.routers.payment.parse_payment_info",
+        new=AsyncMock(
+            return_value=PaymentInfo(
+                amount=1500,
+                is_valid=True,
+                paid_to_maria=True,
+                method_reason="phone match",
+            )
+        ),
+    ):
+        await _handle_screenshot_upload(
+            mock_message,
+            response,
+            user_id=1,
+            username="u",
+            city="Пермь",
+            event_id="aabbccddeeff00112233aabb",
+            guests=[],
+            discount=0,
+            discounted_amount=1500,
+            regular_amount=1500,
+            formula_amount=1500,
+            graduate_type=GraduateType.GRADUATE.value,
+        )
+
+    forwarded_save = mock_app.save_payment_info.await_args_list[-1]
+    assert forwarded_save.kwargs["payment_method"] == "to_maria"
+    assert forwarded_save.kwargs["payment_method_source"] == "ai"
+    caption = bot.send_photo.await_args.kwargs["caption"]
+    assert "Маше" in caption
+
+
+def test_payment_info_method_property():
+    from src.routers.admin import PaymentInfo
+
+    assert PaymentInfo(amount=1, is_valid=True, paid_to_maria=True).payment_method == (
+        "to_maria"
+    )
+    assert PaymentInfo(amount=1, is_valid=True, paid_to_maria=False).payment_method == (
+        "on_site"
+    )
+
+
+def test_payment_method_label():
+    from src.routers.payment import _payment_method_label
+
+    assert "AI" in _payment_method_label("to_maria", source="ai")
+    assert "выбрал" in _payment_method_label("on_site", source="user")
 
 
 # ---- Tests for _get_graduate_type_info ----

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -602,11 +602,13 @@ async def test_send_payment_info_escapes_guest_name_for_telegram_html(
             total_discounted_with_guests=2300,
         )
 
-    guest_message = mock_send_safe.call_args_list[2].args[1]
+    # Price + guests are merged into the first message; how-to-pay is second.
+    first_message = mock_send_safe.call_args_list[0].args[1]
     assert (
-        "&lt;Тег&gt; &amp; &quot;двойная&quot; &#x27;одинарная&#x27;" in guest_message
+        "&lt;Тег&gt; &amp; &quot;двойная&quot; &#x27;одинарная&#x27;" in first_message
     )
-    assert "<Тег> & \"двойная\" 'одинарная'" not in guest_message
+    assert "<Тег> & \"двойная\" 'одинарная'" not in first_message
+    assert len(mock_send_safe.call_args_list) == 2
 
 
 def test_build_user_info_text_teacher():

--- a/tests/test_payment_reminders.py
+++ b/tests/test_payment_reminders.py
@@ -1,10 +1,16 @@
 """Tests for payment reminder selection (no real bot sends)."""
 from datetime import date, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.payment_reminders import send_payment_reminders
+from src.payment_reminders import (
+    daily_reminder_tick,
+    format_admin_preview,
+    send_admin_previews,
+    send_payment_reminders,
+)
+from src.payment_timeline import admin_preview_kinds_for_event
 
 
 @pytest.mark.asyncio
@@ -34,9 +40,19 @@ async def test_send_payment_reminders_d4_marks_flag():
     bot = MagicMock()
     bot.send_message = AsyncMock()
 
-    stats = await send_payment_reminders(
-        app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
-    )
+    with (
+        patch(
+            "src.payment_reminders.get_control",
+            new=AsyncMock(return_value={"paused": False}),
+        ),
+        patch(
+            "src.payment_reminders.mark_auto_send_completed",
+            new=AsyncMock(),
+        ),
+    ):
+        stats = await send_payment_reminders(
+            app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
+        )
     assert stats["d4"] == 1
     assert stats["d2"] == 0
     bot.send_message.assert_awaited_once()
@@ -68,9 +84,158 @@ async def test_send_payment_reminders_skips_already_sent():
     bot = MagicMock()
     bot.send_message = AsyncMock()
 
-    stats = await send_payment_reminders(
-        app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
-    )
+    with patch(
+        "src.payment_reminders.get_control",
+        new=AsyncMock(return_value={"paused": False}),
+    ):
+        stats = await send_payment_reminders(
+            app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
+        )
     assert stats["skipped"] == 1
     assert stats["d4"] == 0
     bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_payment_reminders_respects_pause():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    with patch(
+        "src.payment_reminders.get_control",
+        new=AsyncMock(return_value={"paused": True}),
+    ):
+        stats = await send_payment_reminders(
+            app, bot, now=datetime(2026, 7, 28, 9, 0)
+        )
+    assert stats["paused"] == 1
+    bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_force_send_now_ignores_calendar_and_pause():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    reg = {
+        "_id": "reg1",
+        "user_id": 7,
+        "event_id": "evt1",
+        "payment_status": "not paid",
+    }
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    app.collection.find = MagicMock(
+        return_value=MagicMock(to_list=AsyncMock(return_value=[reg]))
+    )
+    app.collection.update_one = AsyncMock()
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    # Not the reminder day (July 20), but force d4
+    stats = await send_payment_reminders(
+        app,
+        bot,
+        now=datetime(2026, 7, 20, 12, 0),
+        force_event_id="evt1",
+        force_kind="d4",
+        respect_pause=False,
+        only_due_today=False,
+    )
+    assert stats["d4"] == 1
+    bot.send_message.assert_awaited_once()
+
+
+def test_admin_preview_kinds_day_before_reminder():
+    event = {"date": date(2026, 8, 1), "city": "Пермь"}
+    # D-4 send day = Jul 28 → preview Jul 27
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 27, 10)) == [
+        "d4"
+    ]
+    # D-2 send day = Jul 30 → preview Jul 29
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 29, 10)) == [
+        "d2"
+    ]
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 28, 10)) == []
+
+
+def test_format_admin_preview_includes_text_and_recipients():
+    event = {"_id": "aabbccddeeff001122334455", "city": "Пермь", "date": date(2026, 8, 1)}
+    targets = [{"full_name": "Иван", "username": "ivan"}]
+    text = "Hello body"
+    msg = format_admin_preview(
+        event, "d4", targets, text, paused=True, send_date_display="28.07.2026"
+    )
+    assert "Завтра" in msg
+    assert "ПАУЗА" in msg
+    assert "Иван" in msg
+    assert "Hello body" in msg
+
+
+@pytest.mark.asyncio
+async def test_send_admin_previews_marks_sent():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    reg = {"_id": "r1", "user_id": 1, "full_name": "A", "username": "a"}
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    app.collection.find = MagicMock(
+        return_value=MagicMock(to_list=AsyncMock(return_value=[reg]))
+    )
+    app.log_to_chat = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "src.payment_reminders.get_control",
+            new=AsyncMock(return_value={"paused": False, "admin_preview_sent": False}),
+        ),
+        patch(
+            "src.payment_reminders.mark_admin_preview_sent",
+            new=AsyncMock(),
+        ) as mark,
+    ):
+        stats = await send_admin_previews(
+            app, now=datetime(2026, 7, 27, 9, 0), dry_run=False
+        )
+    assert stats["previews"] == 1
+    app.log_to_chat.assert_awaited()
+    mark.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_daily_tick_calls_both():
+    app = MagicMock()
+    bot = MagicMock()
+    with (
+        patch(
+            "src.payment_reminders.send_admin_previews",
+            new=AsyncMock(return_value={"previews": 1}),
+        ) as p,
+        patch(
+            "src.payment_reminders.send_payment_reminders",
+            new=AsyncMock(return_value={"d4": 2}),
+        ) as s,
+    ):
+        out = await daily_reminder_tick(app, bot, now=datetime(2026, 7, 27, 9))
+    assert out["preview"]["previews"] == 1
+    assert out["send"]["d4"] == 2
+    p.assert_awaited_once()
+    s.assert_awaited_once()

--- a/tests/test_payment_reminders.py
+++ b/tests/test_payment_reminders.py
@@ -1,0 +1,76 @@
+"""Tests for payment reminder selection (no real bot sends)."""
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.payment_reminders import send_payment_reminders
+
+
+@pytest.mark.asyncio
+async def test_send_payment_reminders_d4_marks_flag():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    reg = {
+        "_id": "reg1",
+        "user_id": 42,
+        "event_id": "evt1",
+        "payment_status": "not paid",
+        "payment_reminder_d4_sent": False,
+    }
+
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    app.collection.find = MagicMock(
+        return_value=MagicMock(to_list=AsyncMock(return_value=[reg]))
+    )
+    app.collection.update_one = AsyncMock()
+
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    stats = await send_payment_reminders(
+        app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
+    )
+    assert stats["d4"] == 1
+    assert stats["d2"] == 0
+    bot.send_message.assert_awaited_once()
+    app.collection.update_one.assert_awaited()
+    assert "payment_reminder_d4_sent" in str(app.collection.update_one.await_args)
+
+
+@pytest.mark.asyncio
+async def test_send_payment_reminders_skips_already_sent():
+    event = {
+        "_id": "evt1",
+        "date": date(2026, 8, 1),
+        "city": "Пермь",
+        "status": "upcoming",
+        "enabled": True,
+    }
+    reg = {
+        "_id": "reg1",
+        "user_id": 42,
+        "event_id": "evt1",
+        "payment_status": None,
+        "payment_reminder_d4_sent": True,
+    }
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[event])
+    app.collection.find = MagicMock(
+        return_value=MagicMock(to_list=AsyncMock(return_value=[reg]))
+    )
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+
+    stats = await send_payment_reminders(
+        app, bot, now=datetime(2026, 7, 28, 9, 0), dry_run=False
+    )
+    assert stats["skipped"] == 1
+    assert stats["d4"] == 0
+    bot.send_message.assert_not_awaited()

--- a/tests/test_payment_timeline.py
+++ b/tests/test_payment_timeline.py
@@ -1,0 +1,69 @@
+"""Unit tests for payment timeline (D-4 food / D-2 badge, 06:00)."""
+from datetime import date, datetime
+
+from src.payment_timeline import (
+    BADGE_DAYS_BEFORE,
+    FOOD_DAYS_BEFORE,
+    badge_deadline,
+    food_deadline,
+    pay_later_message,
+    reminder_kind_for_event,
+    reminder_message,
+    timeline_for,
+    too_expensive_cancel_message,
+)
+
+
+def _event(day: date | datetime) -> dict:
+    return {"date": day, "city": "Пермь"}
+
+
+def test_deadlines_are_four_and_two_days_before_at_six_am():
+    event = _event(date(2026, 8, 1))
+    food = food_deadline(event)
+    badge = badge_deadline(event)
+    assert food == datetime(2026, 7, 28, 6, 0, 0)
+    assert badge == datetime(2026, 7, 30, 6, 0, 0)
+    assert FOOD_DAYS_BEFORE == 4
+    assert BADGE_DAYS_BEFORE == 2
+
+
+def test_timeline_flags_after_deadlines():
+    event = _event(date(2026, 8, 1))
+    before = timeline_for(event, now=datetime(2026, 7, 27, 12, 0))
+    assert not before.after_food_deadline
+    assert not before.after_badge_deadline
+    mid = timeline_for(event, now=datetime(2026, 7, 29, 12, 0))
+    assert mid.after_food_deadline
+    assert not mid.after_badge_deadline
+    late = timeline_for(event, now=datetime(2026, 7, 31, 12, 0))
+    assert late.after_food_deadline
+    assert late.after_badge_deadline
+
+
+def test_reminder_kind_on_deadline_calendar_days():
+    event = _event(date(2026, 8, 1))
+    assert reminder_kind_for_event(event, now=datetime(2026, 7, 28, 10, 0)) == "d4"
+    assert reminder_kind_for_event(event, now=datetime(2026, 7, 30, 10, 0)) == "d2"
+    assert reminder_kind_for_event(event, now=datetime(2026, 7, 29, 10, 0)) is None
+
+
+def test_pay_later_message_contains_dates_and_rules():
+    event = _event(date(2026, 8, 1))
+    text = pay_later_message(event)
+    assert "28.07.2026" in text
+    assert "30.07.2026" in text
+    assert "еды" in text.lower() or "еду" in text.lower()
+    assert "бейдж" in text.lower()
+    assert "/pay" in text
+
+
+def test_reminder_and_too_expensive_copy():
+    event = _event(date(2026, 8, 1))
+    d4 = reminder_message("d4", event, "Пермь")
+    d2 = reminder_message("d2", event, "Пермь")
+    assert "4 дня" in d4 or "4 дн" in d4
+    assert "бейдж" in d2.lower()
+    cancel = too_expensive_cancel_message()
+    assert "@mariikors" in cancel
+    assert "волонт" in cancel.lower() or "Волонт" in cancel

--- a/tests/test_payment_timeline.py
+++ b/tests/test_payment_timeline.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from src.payment_timeline import (
     BADGE_DAYS_BEFORE,
     FOOD_DAYS_BEFORE,
+    admin_preview_kinds_for_event,
     badge_deadline,
     food_deadline,
     pay_later_message,
@@ -67,3 +68,10 @@ def test_reminder_and_too_expensive_copy():
     cancel = too_expensive_cancel_message()
     assert "@mariikors" in cancel
     assert "волонт" in cancel.lower() or "Волонт" in cancel
+
+
+def test_admin_preview_is_day_before_send():
+    event = _event(date(2026, 8, 1))
+    # send d4 on 28 Jul → preview 27 Jul
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 27, 8)) == ["d4"]
+    assert admin_preview_kinds_for_event(event, now=datetime(2026, 7, 28, 8)) == []

--- a/tests/test_payment_timeline.py
+++ b/tests/test_payment_timeline.py
@@ -6,6 +6,7 @@ from src.payment_timeline import (
     FOOD_DAYS_BEFORE,
     admin_preview_kinds_for_event,
     badge_deadline,
+    early_bird_near_food_cutoff,
     food_deadline,
     pay_later_message,
     reminder_kind_for_event,
@@ -15,8 +16,8 @@ from src.payment_timeline import (
 )
 
 
-def _event(day: date | datetime) -> dict:
-    return {"date": day, "city": "Пермь"}
+def _event(day: date | datetime, **extra) -> dict:
+    return {"date": day, "city": "Пермь", **extra}
 
 
 def test_deadlines_are_four_and_two_days_before_at_six_am():
@@ -59,16 +60,53 @@ def test_pay_later_message_contains_dates_and_rules():
     assert "/pay" in text
 
 
+def test_pay_later_combines_food_and_early_bird():
+    event = _event(date(2026, 8, 1), early_bird_discount=500)
+    text = pay_later_message(event, now=datetime(2026, 7, 1, 12, 0))
+    assert "28.07.2026" in text
+    assert "общий заказ еды" in text
+    assert "скидка за раннюю регистрацию" in text
+    assert "500" in text
+
+
 def test_reminder_and_too_expensive_copy():
     event = _event(date(2026, 8, 1))
     d4 = reminder_message("d4", event, "Пермь")
     d2 = reminder_message("d2", event, "Пермь")
     assert "4 дня" in d4 or "4 дн" in d4
     assert "бейдж" in d2.lower()
+    # TL;DR first line (Telegram preview)
+    assert d4.split("\n", 1)[0].startswith("⏱")
+    assert d2.split("\n", 1)[0].startswith("⏱")
+    assert "еда до 28.07" in d4.split("\n", 1)[0]
+    assert "бейдж до 30.07" in d2.split("\n", 1)[0]
+    # cancel footer on all auto-reminders
+    assert "/cancel_registration" in d4
+    assert "/cancel_registration" in d2
     cancel = too_expensive_cancel_message()
     assert "@mariikors" in cancel
     assert "волонт" in cancel.lower() or "Волонт" in cancel
 
+
+def test_d4_includes_early_bird_aligned_with_food():
+    # Early bird cutoff == food D-4 (28.07 06:00)
+    event = _event(date(2026, 8, 1), early_bird_discount=500)
+    info = early_bird_near_food_cutoff(event)
+    assert info is not None
+    assert info.discount == 500
+    assert info.deadline_short == "28.07"
+    d4 = reminder_message("d4", event, "Пермь")
+    first = d4.split("\n", 1)[0]
+    assert "ранняя" in first.lower() or "−500" in first or "-500" in first
+    assert "500" in d4
+    assert "28.07" in d4
+
+
+def test_d4_skips_early_bird_when_no_discount():
+    event = _event(date(2026, 8, 1), early_bird_discount=0)
+    assert early_bird_near_food_cutoff(event) is None
+    d4 = reminder_message("d4", event, "Пермь")
+    assert "ранняя" not in d4.lower()
 
 def test_admin_preview_is_day_before_send():
     event = _event(date(2026, 8, 1))

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -26,7 +26,9 @@ def mock_app():
     mock_app = MagicMock()
     # Configure async src mocks with AsyncMock
     mock_app.get_user_registration = AsyncMock(return_value=None)
+    mock_app.get_profile_for_reuse = AsyncMock(return_value=None)
     mock_app.get_user_registrations = AsyncMock(return_value=[])
+    mock_app.get_user_active_registrations = AsyncMock(return_value=[])
     mock_app.log_registration_step = AsyncMock(return_value=None)
     mock_app.save_registered_user = AsyncMock()
     mock_app.export_registered_users_to_google_sheets = AsyncMock()
@@ -98,14 +100,14 @@ async def test_start_handler_existing_summer_user(
     )
     mock_app.is_event_passed = MagicMock(return_value=False)
     mock_app.get_user_active_registrations = AsyncMock(return_value=[])
-    mock_app.get_user_registration = AsyncMock(
-        return_value={
-            "full_name": "Test User",
-            "graduation_year": 2010,
-            "class_letter": "A",
-            "target_city": "Пермь (Летняя встреча 2025)",
-        }
-    )
+    profile = {
+        "full_name": "Test User",
+        "graduation_year": 2010,
+        "class_letter": "A",
+        "target_city": "Пермь (Летняя встреча 2025)",
+    }
+    mock_app.get_user_registration = AsyncMock(return_value=profile)
+    mock_app.get_profile_for_reuse = AsyncMock(return_value=profile)
 
     # Mock ask_user_choice to simulate user cancelling
     with patch("src.router.ask_user_choice") as mock_ask:

--- a/tests/test_router_utils.py
+++ b/tests/test_router_utils.py
@@ -125,15 +125,17 @@ class TestFormatEventSummary:
         event = {
             "name": "Test",
             "city": "Москва",
+            "date": datetime(2026, 3, 22, 18, 0),
             "pricing_type": "free",
             "status": "upcoming",
             "enabled": True,
             "early_bird_discount": 500,
-            "early_bird_deadline": datetime(2026, 3, 18),
         }
         result = _format_event_summary(event)
         assert "500" in result
+        # Early bird = food D-4 06:00 → 18.03.2026
         assert "18.03.2026" in result
+        assert "заказа еды" in result
 
     def test_guests_enabled(self):
         event = {

--- a/tests/test_ticket_cards.py
+++ b/tests/test_ticket_cards.py
@@ -1,0 +1,282 @@
+"""Paid ticket-card gate, rendering, delivery, and `/status` recovery tests."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiogram.types import BufferedInputFile
+from PIL import Image
+
+from src.ticket_cards import (
+    CARD_SIZE,
+    TicketCardError,
+    _font,
+    build_ticket_card_data,
+    is_ticket_unlocked,
+    make_ticket_card,
+    send_paid_ticket_card,
+)
+
+
+EVENT_ID = "6a599a17a37724d81b7eadc3"
+
+
+def _registration(status="confirmed", **updates):
+    registration = {
+        "_id": "6a6011111111111111111111",
+        "user_id": 123456789,
+        "event_id": EVENT_ID,
+        "full_name": "Лавров Петр",
+        "graduate_type": "GRADUATE",
+        "graduation_year": 2007,
+        "class_letter": "А",
+        "payment_status": status,
+        "payment_amount": 2500,
+        "target_city": "Пермь",
+    }
+    registration.update(updates)
+    return registration
+
+
+def _event(**updates):
+    event = {
+        "_id": EVENT_ID,
+        "name": "Летняя встреча выпускников 2026",
+        "city": "Пермь",
+        "date_display": "1 Августа, Сб",
+        "time_display": "18:00",
+        "venue": 'Беседка "Журавушка"',
+        "address": 'г.Пермь, ул. Встречная 28, беседка "Журавушка"',
+        "pricing_type": "formula",
+        "free_for_types": [],
+    }
+    event.update(updates)
+    return event
+
+
+def test_confirmed_registration_renders_deterministic_png():
+    first = make_ticket_card(_registration(), _event())
+    second = make_ticket_card(_registration(), _event())
+
+    assert first == second
+    assert first.ticket_code.startswith("146-")
+    assert sha256(first.image).hexdigest() == sha256(second.image).hexdigest()
+    assert "Лавров" not in first.filename
+
+    image = Image.open(BytesIO(first.image))
+    assert image.format == "PNG"
+    assert image.size == CARD_SIZE
+    assert image.mode == "RGB"
+
+
+def test_ticket_font_is_portable_and_supports_cyrillic():
+    assert _font(24).getname()[0] == "DejaVu Sans"
+
+
+def test_visual_code_is_bound_to_event_registration_and_telegram_user():
+    original = build_ticket_card_data(_registration(), _event()).ticket_code
+    other_user = build_ticket_card_data(
+        _registration(user_id=987654321), _event()
+    ).ticket_code
+    other_registration = build_ticket_card_data(
+        _registration(_id="6a6022222222222222222222"), _event()
+    ).ticket_code
+
+    assert len({original, other_user, other_registration}) == 3
+
+
+def test_immediate_card_lists_up_to_three_named_guests_as_one_group():
+    registration = _registration(
+        guests=[{"name": "Анна"}, {"name": "Борис"}, {"name": "Вера"}]
+    )
+    data = build_ticket_card_data(registration, _event())
+    artifact = make_ticket_card(registration, _event())
+
+    assert data.guest_names == ["Анна", "Борис", "Вера"]
+    assert artifact.image != make_ticket_card(_registration(), _event()).image
+
+
+def test_more_than_three_guests_fails_closed_instead_of_omitting_a_person():
+    registration = _registration(
+        guests=[{"name": f"Гость {index}"} for index in range(4)]
+    )
+    with pytest.raises(TicketCardError, match="at most three"):
+        make_ticket_card(registration, _event())
+
+
+@pytest.mark.parametrize(
+    "status", [None, "not paid", "Не оплачено", "pending", "declined", "paid"]
+)
+def test_unconfirmed_registration_never_unlocks_or_renders(status):
+    registration = _registration(status=status)
+
+    assert is_ticket_unlocked(registration) is False
+    with pytest.raises(TicketCardError, match="payment_status == confirmed"):
+        make_ticket_card(registration, _event())
+
+
+def test_event_binding_mismatch_fails_closed():
+    with pytest.raises(TicketCardError, match="does not match"):
+        make_ticket_card(_registration(), _event(_id="other-event"))
+
+
+def test_future_website_ticket_code_is_additive_and_preferred():
+    artifact = make_ticket_card(
+        _registration(ticket_code="CLUB146-PAID-ABC123"), _event()
+    )
+
+    assert artifact.ticket_code == "CLUB146-PAID-ABC123"
+    assert artifact.filename.endswith("CLUB146-PAID-ABC123.png")
+
+
+def test_invalid_future_website_ticket_code_fails_closed():
+    with pytest.raises(TicketCardError, match="Invalid website-issued"):
+        make_ticket_card(_registration(ticket_code="../../not-a-ticket"), _event())
+
+
+@pytest.mark.asyncio
+async def test_send_paid_ticket_card_uses_telegram_photo():
+    bot = AsyncMock()
+    dependencies = MagicMock(bot=bot)
+    with patch("src.ticket_cards.get_dependency_manager", return_value=dependencies):
+        sent = await send_paid_ticket_card(123456789, _registration(), _event())
+
+    assert sent is True
+    call = bot.send_photo.await_args
+    assert call is not None
+    assert call.kwargs["chat_id"] == 123456789
+    assert call.kwargs["parse_mode"] is None
+    assert isinstance(call.kwargs["photo"], BufferedInputFile)
+    assert "Покажите эту карточку на входе" in call.kwargs["caption"]
+
+
+@pytest.mark.asyncio
+async def test_send_paid_ticket_card_does_not_touch_telegram_when_unpaid():
+    with patch("src.ticket_cards.get_dependency_manager") as dependencies:
+        sent = await send_paid_ticket_card(
+            123456789, _registration(status="pending"), _event()
+        )
+
+    assert sent is False
+    dependencies.assert_not_called()
+
+
+def _status_message():
+    message = AsyncMock()
+    message.from_user = MagicMock(id=123456789, username="petr")
+    message.chat = MagicMock(id=123456789, type="private")
+    message.text = "/status"
+    return message
+
+
+def _status_app(registration):
+    app = MagicMock()
+    app.save_event_log = AsyncMock()
+    app.get_user_active_registrations = AsyncMock(return_value=[registration])
+    app.get_event_for_registration = AsyncMock(return_value=_event())
+    app.get_enabled_events = AsyncMock(return_value=[_event()])
+    app.is_event_passed = MagicMock(return_value=False)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_status_resends_confirmed_ticket_card():
+    from src.router import status_handler
+
+    registration = _registration()
+    app = _status_app(registration)
+    with (
+        patch("src.router.send_safe", new_callable=AsyncMock) as send_safe,
+        patch("src.router.send_paid_ticket_card", new_callable=AsyncMock) as send_card,
+    ):
+        await status_handler(_status_message(), AsyncMock(), app)
+
+    status_text = send_safe.await_args.args[1]
+    assert "Именной билет действителен для входа и доступен ниже" in status_text
+    send_card.assert_awaited_once_with(123456789, registration, _event())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [None, "not paid", "pending", "declined"])
+async def test_status_never_sends_unconfirmed_ticket_card(status):
+    from src.router import status_handler
+
+    registration = _registration(status=status)
+    app = _status_app(registration)
+    with (
+        patch("src.router.send_safe", new_callable=AsyncMock) as send_safe,
+        patch("src.router.send_paid_ticket_card", new_callable=AsyncMock) as send_card,
+    ):
+        await status_handler(_status_message(), AsyncMock(), app)
+
+    status_text = send_safe.await_args.args[1]
+    assert "Заявка сохранена; действующего билета пока нет" in status_text
+    assert "после подтверждения оплаты" in status_text
+    send_card.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_admin_receipt_confirmation_sends_newly_unlocked_ticket():
+    from src.routers.payment import confirm_payment_callback
+
+    registration = _registration(
+        payment_status="pending",
+        discounted_payment_amount=2500,
+        regular_payment_amount=3000,
+    )
+    updated_registration = _registration(
+        payment_status="confirmed",
+        payment_amount=2500,
+        payment_history=[{"amount": 2500, "timestamp": "2026-07-20T12:00:00"}],
+        discounted_payment_amount=2500,
+        regular_payment_amount=3000,
+    )
+
+    callback = AsyncMock()
+    callback.data = f"confirm_payment_123456789_{EVENT_ID}_2500"
+    callback.message = AsyncMock()
+    callback.message.chat = MagicMock(id=-100146)
+    callback.message.caption = None
+    callback.message.text = "Проверка пожертвования"
+    callback.message.edit_reply_markup = AsyncMock()
+    callback.message.edit_text = AsyncMock()
+    callback.answer = AsyncMock()
+
+    state = AsyncMock()
+    state.get_state.return_value = None
+
+    app = MagicMock()
+    app.update_payment_status = AsyncMock()
+    app.collection.find_one = AsyncMock(return_value=updated_registration)
+    app.get_event_for_registration = AsyncMock(return_value=_event())
+    app.export_registered_users_to_google_sheets = AsyncMock()
+
+    with (
+        patch("src.routers.payment.app", app),
+        patch(
+            "src.routers.payment._resolve_registration_from_callback",
+            new_callable=AsyncMock,
+            return_value=registration,
+        ),
+        patch(
+            "src.routers.payment._resolve_payment_amount",
+            new_callable=AsyncMock,
+            return_value=2500,
+        ),
+        patch("src.routers.payment.send_safe", new_callable=AsyncMock),
+        patch(
+            "src.routers.payment.send_paid_ticket_card", new_callable=AsyncMock
+        ) as send_card,
+    ):
+        await confirm_payment_callback(callback, state)
+
+    app.update_payment_status.assert_awaited_once_with(
+        123456789,
+        event_id=EVENT_ID,
+        status="confirmed",
+        payment_amount=2500,
+    )
+    send_card.assert_awaited_once_with(123456789, updated_registration, _event())

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -195,8 +195,8 @@ class TestCalculateEventPayment:
             "price_formula_reference_year": 2026,
             "price_formula_step": 1,
             "free_for_types": [],
+            "date": datetime(2099, 6, 1),
             "early_bird_discount": 500,
-            "early_bird_deadline": datetime(2099, 1, 1),
         }
         regular, discount, discounted, formula = app.calculate_event_payment(
             event, 2025
@@ -212,8 +212,8 @@ class TestCalculateEventPayment:
             "price_formula_reference_year": 2026,
             "price_formula_step": 1,
             "free_for_types": [],
+            "date": datetime(2020, 1, 10),
             "early_bird_discount": 500,
-            "early_bird_deadline": datetime(2020, 1, 1),
         }
         regular, discount, discounted, formula = app.calculate_event_payment(
             event, 2025
@@ -277,8 +277,8 @@ class TestCalculateEventPayment:
             "price_formula_reference_year": 2025,
             "price_formula_step": 3,
             "free_for_types": [],
+            "date": datetime(2099, 6, 1),
             "early_bird_discount": 500,
-            "early_bird_deadline": datetime(2099, 1, 1),
         }
         # base + rate * (15 // 3) = 1500 + 500*5 = 4000, early bird → 3500
         result = app.calculate_event_payment(event, 2020, "NON_GRADUATE")
@@ -337,8 +337,8 @@ class TestCalculateGuestPrice:
     def test_early_bird_applied(self, app):
         event = {
             "guest_price_minimum": 1000,
+            "date": datetime(2099, 6, 1),
             "early_bird_discount": 500,
-            "early_bird_deadline": datetime(2099, 1, 1),
         }
         # max(1000, 2000) = 2000 regular, minus 500 = 1500 discounted
         assert app.calculate_guest_price(event, 2000) == (2000, 1500)
@@ -346,15 +346,15 @@ class TestCalculateGuestPrice:
     def test_early_bird_expired(self, app):
         event = {
             "guest_price_minimum": 1000,
+            "date": datetime(2020, 1, 10),
             "early_bird_discount": 500,
-            "early_bird_deadline": datetime(2020, 1, 1),
         }
         assert app.calculate_guest_price(event, 2000) == (2000, 2000)
 
     def test_early_bird_floor_zero(self, app):
         event = {
+            "date": datetime(2099, 6, 1),
             "early_bird_discount": 9999,
-            "early_bird_deadline": datetime(2099, 1, 1),
         }
         assert app.calculate_guest_price(event, 500) == (500, 0)
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,10 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P14D"
+
 [[package]]
 name = "aiofiles"
 version = "25.1.0"
@@ -2931,7 +2935,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3817,6 +3821,7 @@ dependencies = [
     { name = "motor" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -3867,6 +3872,7 @@ requires-dist = [
     { name = "motor" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "pandas", specifier = ">=2.2.1" },
+    { name = "pillow", specifier = ">=12.1.1,<13" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "python-dotenv" },
@@ -4125,8 +4131,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
b07b7c5 Merge pay UX improvements into dev
30cf552 Improve pay UX: AI destination, aligned early bird, clearer reminders
00b9194 Merge pull request #53 from Club-146/agent/payment-reminder-scheduler
7fd646a Bring remaining Lizard CCN hotspots under threshold
83adc94 Reduce admin_handler complexity for Lizard advisory check
5a4ed75 Fix Ruff CI: format, drop unused import, lower reminder CCN
7c4f6e6 Auto payment reminders with admin preview and pause controls
7884474 Fix start-handler test mock for get_profile_for_reuse
d20451a Merge late payment timeline and admin free/discount (#52)
1dde43a Late payment timeline, fewer pay messages, admin free/discount
5db13c0 Merge pull request #51 from Club-146/codex/aug1-paid-ticket-card
f53c2a6 Send tickets after manual payment confirmation
d3aefdf Add confirmed-payment entry ticket cards
fe2fdb5 Season rollover option A: newest registration wins; all_time city audience reaches historical rows