### PR TITLE
Add deep-link source tracking and full-base CRM broadcast

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -101,6 +101,8 @@ class RegisteredUser(BaseModel):
     user_id: Optional[int] = None
     username: Optional[str] = None
     graduate_type: GraduateType = GraduateType.GRADUATE
+    # Telegram deep-link payload from /start <payload> (e.g. email_campaign)
+    start_source: Optional[str] = None
 
 
 class FeedbackData(BaseModel):
@@ -135,6 +137,7 @@ class App:
     event_logs_collection_name = "event_logs"
     deleted_users_collection_name = "deleted_users"
     events_collection_name = "events"
+    user_sources_collection_name = "user_sources"
 
     def __init__(self, **kwargs):
         from src.export import SheetExporter
@@ -148,6 +151,7 @@ class App:
         self._event_logs = None
         self._deleted_users = None
         self._events_col = None
+        self._user_sources = None
         self._export_debounce_task: asyncio.Task | None = None
         self._export_debounce_seconds = 30
 
@@ -160,6 +164,7 @@ class App:
         _ = self.event_logs
         _ = self.deleted_users
         _ = self.events_col
+        _ = self.user_sources
 
         # Run database migrations (includes seeding new events + archiving old ones)
         from src.migrations import run_migrations
@@ -209,6 +214,85 @@ class App:
                 self.events_collection_name
             )
         return self._events_col
+
+    @property
+    def user_sources(self):
+        """Acquisition sources from Telegram deep links (?start=payload)."""
+        if self._user_sources is None:
+            self._user_sources = get_database().get_collection(
+                self.user_sources_collection_name
+            )
+        return self._user_sources
+
+    @staticmethod
+    def normalize_start_payload(raw: Optional[str]) -> Optional[str]:
+        """Telegram start payloads: 1–64 chars of A–Z a–z 0–9 _ -."""
+        if not raw:
+            return None
+        payload = raw.strip()
+        if not payload or len(payload) > 64:
+            return None
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", payload):
+            return None
+        return payload
+
+    async def record_start_source(
+        self,
+        user_id: int,
+        source: str,
+        username: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        Persist deep-link start payload for attribution.
+
+        Keeps first_source (immutable) and last_source (updated each start),
+        plus a short history list. Also writes an event_logs entry.
+        """
+        payload = self.normalize_start_payload(source)
+        if not payload or user_id is None:
+            return None
+
+        now = datetime.now().isoformat()
+        existing = await self.user_sources.find_one({"user_id": user_id})
+        history_entry = {"source": payload, "at": now}
+
+        if existing:
+            await self.user_sources.update_one(
+                {"user_id": user_id},
+                {
+                    "$set": {
+                        "last_source": payload,
+                        "last_source_at": now,
+                        "username": username,
+                    },
+                    "$push": {
+                        "history": {
+                            "$each": [history_entry],
+                            "$slice": -50,
+                        }
+                    },
+                },
+            )
+        else:
+            await self.user_sources.insert_one(
+                {
+                    "user_id": user_id,
+                    "username": username,
+                    "first_source": payload,
+                    "first_source_at": now,
+                    "last_source": payload,
+                    "last_source_at": now,
+                    "history": [history_entry],
+                }
+            )
+
+        await self.save_event_log(
+            "start_source",
+            {"source": payload, "is_first": existing is None},
+            user_id,
+            username,
+        )
+        return payload
 
     # ---- Event methods ----
 
@@ -447,6 +531,11 @@ class App:
             "target_city": data.get("target_city"),
             "graduate_type": data.get("graduate_type"),
         }
+        if data.get("start_source"):
+            log_data["start_source"] = data["start_source"]
+        # Drop None start_source so we don't overwrite an existing stamp on update
+        if data.get("start_source") is None:
+            data.pop("start_source", None)
 
         # Check if user is already registered for this specific event
         is_update = False
@@ -1161,6 +1250,36 @@ class App:
     ) -> List[Dict]:
         """Get all users regardless of payment status."""
         return await self._get_users_base(event_id=event_id, active_only=active_only)
+
+    async def get_all_time_broadcast_users(
+        self, history_query: Optional[Dict] = None
+    ) -> List[Dict]:
+        """
+        One profile per Telegram user from active + deleted registrations.
+
+        Used for CRM broadcast to the full historical base (not only current
+        season). Prefer the active registration when both exist; otherwise the
+        most recent deleted row. Optional history_query filters both collections
+        the same way (city / event history).
+        """
+        query = history_query or {}
+        active_cursor = self.collection.find(query)
+        deleted_cursor = self.deleted_users.find(query)
+        active_rows = await active_cursor.to_list(length=None)
+        deleted_rows = await deleted_cursor.to_list(length=None)
+
+        by_user: Dict[int, Dict] = {}
+        # Deleted first, then active overwrites — active wins for the same user.
+        for row in deleted_rows:
+            user_id = row.get("user_id")
+            if user_id is not None:
+                by_user[user_id] = row
+        for row in active_rows:
+            user_id = row.get("user_id")
+            if user_id is not None:
+                by_user[user_id] = row
+
+        return list(by_user.values())
 
     async def _fix_database(self) -> Dict[str, int]:
         """

--- a/src/router.py
+++ b/src/router.py
@@ -1413,6 +1413,8 @@ async def register_user(
     assert full_name is not None, "full_name must be set by this point"
     assert graduation_year is not None, "graduation_year must be set by this point"
     assert class_letter is not None, "class_letter must be set by this point"
+    state_data = await state.get_data()
+    start_source = App.normalize_start_payload(state_data.get("start_source"))
     registered_user = RegisteredUser(
         full_name=full_name,
         graduation_year=graduation_year,
@@ -1420,6 +1422,7 @@ async def register_user(
         target_city=target_city_value,
         event_id=event_id,
         graduate_type=graduate_type,
+        start_source=start_source,
     )
     await app.save_registered_user(registered_user, user_id=user_id, username=username)
 
@@ -1949,6 +1952,29 @@ async def _show_multi_event_welcome(
     await register_user(message, state, app, reuse_info=reuse_info)
 
 
+def extract_start_payload(message: Message) -> Optional[str]:
+    """
+    Parse Telegram deep-link payload from /start.
+
+    Deep links look like:
+      https://t.me/<bot>?start=email_campaign
+    which arrives as:
+      /start email_campaign
+      /start@bot_username email_campaign
+    """
+    raw = message.text
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text.startswith("/start"):
+        return None
+    # Drop command token (/start or /start@bot)
+    parts = text.split(maxsplit=1)
+    if len(parts) < 2:
+        return None
+    return App.normalize_start_payload(parts[1])
+
+
 @commands_menu.add_command("start", "Start the bot")
 @router.message(CommandStart())
 @router.message(
@@ -1959,17 +1985,28 @@ async def start_handler(message: Message, state: FSMContext, app: App):
     Main scenario flow.
     """
     assert message.from_user is not None
+    start_payload = extract_start_payload(message)
     if message.from_user:
+        log_data = {
+            "command": "/start",
+            "content": message.text,
+            "chat_type": message.chat.type,
+        }
+        if start_payload:
+            log_data["start_payload"] = start_payload
         await app.save_event_log(
             "command",
-            {
-                "command": "/start",
-                "content": message.text,
-                "chat_type": message.chat.type,
-            },
+            log_data,
             message.from_user.id,
             message.from_user.username,
         )
+        if start_payload:
+            await app.record_start_source(
+                message.from_user.id,
+                start_payload,
+                username=message.from_user.username,
+            )
+            await state.update_data(start_source=start_payload)
 
     if is_admin(message.from_user):
         result = await admin_handler(message, state, app=app)

--- a/src/routers/crm.py
+++ b/src/routers/crm.py
@@ -78,8 +78,45 @@ _TEMPLATE_MARKERS = [
 ]
 
 
-async def _get_notify_users(app: App, audience: str, city_filter) -> tuple:
-    """Fetch the target user list and a display name for the audience."""
+def _all_time_history_query(city_filter, event_map: dict, all_events: list) -> dict:
+    """Mongo query for historical registrations in a city (or empty = all cities)."""
+    if city_filter is None or city_filter == "all":
+        return {}
+    ev = event_map.get(city_filter, {})
+    city = ev.get("city", "")
+    if not city:
+        return {"event_id": city_filter}
+    city_event_ids = [str(e["_id"]) for e in all_events if e.get("city") == city]
+    return {
+        "$or": [
+            {"event_id": {"$in": city_event_ids}},
+            {"target_city": {"$regex": f"^{re.escape(city)}"}},
+        ]
+    }
+
+
+async def _get_notify_users(
+    app: App,
+    audience: str,
+    city_filter,
+    *,
+    scope: str = "current",
+    event_map: Optional[dict] = None,
+) -> tuple:
+    """Fetch the target user list and a display name for the audience.
+
+    scope:
+      - current — only registrations for active/current events (paid/unpaid/all)
+      - all_time — full historical base (active + deleted), payment filters N/A
+    """
+    if scope == "all_time":
+        all_events = await app.get_all_events()
+        history_query = _all_time_history_query(
+            city_filter, event_map or {}, all_events
+        )
+        users = await app.get_all_time_broadcast_users(history_query)
+        return users, "пользователей из всей базы"
+
     if audience == "unpaid":
         users = await app.get_unpaid_users(
             event_id=city_filter, active_only=city_filter is None
@@ -199,24 +236,49 @@ async def notify_users_handler(message: Message, state: FSMContext, app: App):
         await send_safe(message.chat.id, "❌ Ошибка: не удалось определить отправителя")
         return
 
-    # Step 1: audience
-    audience = await ask_user_choice(
+    # Step 1: base scope — current season vs full historical database
+    scope = await ask_user_choice(
         message.chat.id,
-        "Шаг 1: Кому отправить уведомление?",
+        "Шаг 1: Какую базу использовать?",
         choices={
-            "unpaid": "Неоплатившим пользователям",
-            "paid": "Оплатившим пользователям",
-            "all": "Всем пользователям",
+            "current": "Только текущие регистрации",
+            "all_time": "Вся база (все сезоны + удалённые)",
             "cancel": "Отмена",
         },
         state=state,
         timeout=None,
     )
-    if audience == "cancel":
+    if scope == "cancel":
         await send_safe(message.chat.id, "Операция отменена")
         return
 
-    # Step 2: city
+    # Step 2: payment audience (only for current-season registrations)
+    audience = "all"
+    if scope == "current":
+        audience = await ask_user_choice(
+            message.chat.id,
+            "Шаг 2: Кому отправить уведомление?",
+            choices={
+                "unpaid": "Неоплатившим пользователям",
+                "paid": "Оплатившим пользователям",
+                "all": "Всем пользователям",
+                "cancel": "Отмена",
+            },
+            state=state,
+            timeout=None,
+        )
+        if audience == "cancel":
+            await send_safe(message.chat.id, "Операция отменена")
+            return
+        city_step = "Шаг 3"
+        message_step = "Шаг 4"
+        confirm_step = "Шаг 5"
+    else:
+        city_step = "Шаг 2"
+        message_step = "Шаг 3"
+        confirm_step = "Шаг 4"
+
+    # City filter
     city_choices = {"all": "Все города", "cancel": "Отмена"}
     enabled_events = await app.get_enabled_events()
     event_map = {}
@@ -227,7 +289,7 @@ async def notify_users_handler(message: Message, state: FSMContext, app: App):
 
     city = await ask_user_choice(
         message.chat.id,
-        "Шаг 2: Выберите город для рассылки",
+        f"{city_step}: Выберите город для рассылки",
         choices=city_choices,
         state=state,
         timeout=None,
@@ -236,10 +298,10 @@ async def notify_users_handler(message: Message, state: FSMContext, app: App):
         await send_safe(message.chat.id, "Операция отменена")
         return
 
-    # Step 3: message text
+    # Message text
     response = await ask_user_raw(
         message.chat.id,
-        "Шаг 3: Введите текст сообщения для отправки\n\n"
+        f"{message_step}: Введите текст сообщения для отправки\n\n"
         "Доступные шаблоны для подстановки:\n"
         "- {name} - имя пользователя\n"
         "- {city} - название города\n"
@@ -267,7 +329,9 @@ async def notify_users_handler(message: Message, state: FSMContext, app: App):
     )
 
     city_filter = city if city != "all" else None
-    users, audience_name = await _get_notify_users(app, audience, city_filter)
+    users, audience_name = await _get_notify_users(
+        app, audience, city_filter, scope=scope, event_map=event_map
+    )
 
     if not users:
         await status_msg.edit_text(
@@ -281,10 +345,10 @@ async def notify_users_handler(message: Message, state: FSMContext, app: App):
     )
     await status_msg.edit_text(preview)
 
-    # Step 4: confirm
+    # Confirm
     confirm = await ask_user_confirmation(
         message.chat.id,
-        f"Шаг 4: ⚠️ Вы собираетесь отправить сообщение {len(users)} пользователям. Продолжить?",
+        f"{confirm_step}: ⚠️ Вы собираетесь отправить сообщение {len(users)} пользователям. Продолжить?",
         state=state,
     )
     if not confirm:

--- a/tests/test_crm_recipients.py
+++ b/tests/test_crm_recipients.py
@@ -150,10 +150,50 @@ async def test_notify_all_events_requests_active_recipient_scope(audience, metho
     get_users = AsyncMock(return_value=[{"user_id": 1}])
     setattr(app, method_name, get_users)
 
-    recipients, _ = await _get_notify_users(app, audience, None)
+    recipients, _ = await _get_notify_users(app, audience, None, scope="current")
 
     assert recipients == [{"user_id": 1}]
     get_users.assert_awaited_once_with(event_id=None, active_only=True)
+
+
+@pytest.mark.asyncio
+async def test_notify_all_time_scope_uses_full_historical_base():
+    app = MagicMock()
+    app.get_all_events = AsyncMock(
+        return_value=[
+            {"_id": "perm-2026", "city": "Пермь"},
+            {"_id": "perm-old", "city": "Пермь"},
+        ]
+    )
+    app.get_all_time_broadcast_users = AsyncMock(
+        return_value=[{"user_id": 1}, {"user_id": 2}, {"user_id": 3}]
+    )
+    event_map = {"perm-2026": {"city": "Пермь"}}
+
+    recipients, name = await _get_notify_users(
+        app, "all", "perm-2026", scope="all_time", event_map=event_map
+    )
+
+    assert len(recipients) == 3
+    assert "всей базы" in name
+    query = app.get_all_time_broadcast_users.await_args.args[0]
+    event_clause, city_clause = query["$or"]
+    assert set(event_clause["event_id"]["$in"]) == {"perm-2026", "perm-old"}
+    assert city_clause["target_city"]["$regex"] == "^Пермь"
+
+
+@pytest.mark.asyncio
+async def test_notify_all_time_all_cities_uses_empty_history_query():
+    app = MagicMock()
+    app.get_all_events = AsyncMock(return_value=[])
+    app.get_all_time_broadcast_users = AsyncMock(return_value=[{"user_id": 9}])
+
+    recipients, _ = await _get_notify_users(
+        app, "all", None, scope="all_time", event_map={}
+    )
+
+    assert recipients == [{"user_id": 9}]
+    app.get_all_time_broadcast_users.assert_awaited_once_with({})
 
 
 @pytest.mark.asyncio

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -13,6 +13,7 @@ def mock_message():
     message.from_user.username = "test_user"
     message.chat = MagicMock()
     message.chat.id = 12345
+    message.text = "/start"
     return message
 
 
@@ -36,6 +37,7 @@ def mock_app():
     mock_app.log_registration_canceled = AsyncMock()
     mock_app.log_registration_completed = AsyncMock()
     mock_app.save_event_log = AsyncMock()
+    mock_app.record_start_source = AsyncMock(return_value=None)
     yield mock_app
 
 

--- a/tests/test_start_source.py
+++ b/tests/test_start_source.py
@@ -1,0 +1,109 @@
+"""Tests for Telegram deep-link start payload attribution."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.app import App
+from src.router import extract_start_payload
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("/start", None),
+        ("/start email_campaign", "email_campaign"),
+        ("/start@register_146_meetup_2025_bot email_campaign", "email_campaign"),
+        ("/start group_chat", "group_chat"),
+        ("/start partner-ivan_01", "partner-ivan_01"),
+        ("/start bad payload spaces", None),
+        ("/start " + ("x" * 65), None),
+        ("hello", None),
+        ("", None),
+    ],
+)
+def test_extract_start_payload(text, expected):
+    message = MagicMock()
+    message.text = text
+    assert extract_start_payload(message) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("email_campaign", "email_campaign"),
+        ("  dm  ", "dm"),
+        ("bad space", None),
+        ("", None),
+        (None, None),
+        ("x" * 64, "x" * 64),
+        ("x" * 65, None),
+        ("has.dot", None),
+    ],
+)
+def test_normalize_start_payload(raw, expected):
+    assert App.normalize_start_payload(raw) == expected
+
+
+@pytest.mark.asyncio
+async def test_record_start_source_first_and_last():
+    app = App.__new__(App)
+    sources = MagicMock()
+    sources.find_one = AsyncMock(return_value=None)
+    sources.insert_one = AsyncMock()
+    sources.update_one = AsyncMock()
+    app._user_sources = sources
+    app.save_event_log = AsyncMock()
+
+    first = await App.record_start_source(app, 42, "email_campaign", username="maria")
+    assert first == "email_campaign"
+    sources.insert_one.assert_awaited_once()
+    inserted = sources.insert_one.await_args.args[0]
+    assert inserted["first_source"] == "email_campaign"
+    assert inserted["last_source"] == "email_campaign"
+    assert inserted["user_id"] == 42
+
+    sources.find_one = AsyncMock(
+        return_value={
+            "user_id": 42,
+            "first_source": "email_campaign",
+            "last_source": "email_campaign",
+        }
+    )
+    second = await App.record_start_source(app, 42, "group_chat", username="maria")
+    assert second == "group_chat"
+    sources.update_one.assert_awaited_once()
+    update = sources.update_one.await_args.args[1]
+    assert update["$set"]["last_source"] == "group_chat"
+    assert update["$set"]["first_source"] if False else True  # first not in $set
+    assert "first_source" not in update["$set"]
+
+
+@pytest.mark.asyncio
+async def test_get_all_time_broadcast_users_prefers_active_over_deleted():
+    app = App.__new__(App)
+    active = [
+        {"user_id": 1, "full_name": "Active One", "event_id": "e1"},
+        {"user_id": 2, "full_name": "Active Two", "event_id": "e1"},
+    ]
+    deleted = [
+        {"user_id": 1, "full_name": "Deleted One", "event_id": "old"},
+        {"user_id": 3, "full_name": "Deleted Three", "event_id": "old"},
+    ]
+
+    active_cursor = MagicMock()
+    active_cursor.to_list = AsyncMock(return_value=active)
+    deleted_cursor = MagicMock()
+    deleted_cursor.to_list = AsyncMock(return_value=deleted)
+
+    app._collection = MagicMock()
+    app._collection.find = MagicMock(return_value=active_cursor)
+    app._deleted_users = MagicMock()
+    app._deleted_users.find = MagicMock(return_value=deleted_cursor)
+
+    users = await App.get_all_time_broadcast_users(app)
+    by_id = {u["user_id"]: u["full_name"] for u in users}
+    assert by_id[1] == "Active One"
+    assert by_id[2] == "Active Two"
+    assert by_id[3] == "Deleted Three"
+    assert len(users) == 3


### PR DESCRIPTION
## Summary
- Track Telegram deep-link `?start=` payloads (`first_source` / `last_source` in `user_sources`, stamp on registration)
- Extend admin `/notify` with **Вся база (все сезоны + удалённые)** so broadcast is not limited to current-event registrants
- Tests for payload parsing, source recording, and all-time recipient selection

## For Maria / ops
Email link (prod): `https://t.me/register_146_meetup_2025_bot?start=email_campaign`

Broadcast: Admin → Рассылка → **Вся база** → Все города → message → confirm

## Test plan
- [x] `uv run pytest` — 619 passed
- [ ] Staging: open test bot with `?start=email_campaign`, confirm `user_sources` row
- [ ] Staging: `/notify` → Вся база → preview count much larger than current-only
- [ ] Prod after Coolify deploy: same smoke checks