### PR TITLE
Campaign source stats, all clicks, before_tracking backfill

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6,7 +6,7 @@ from enum import Enum
 from loguru import logger
 from pydantic import SecretStr, BaseModel
 from pydantic_settings import BaseSettings
-from typing import Optional, Tuple, List, Dict
+from typing import Any, Optional, Tuple, List, Dict
 
 from botspot import get_database
 from botspot.utils import send_safe
@@ -138,6 +138,10 @@ class App:
     deleted_users_collection_name = "deleted_users"
     events_collection_name = "events"
     user_sources_collection_name = "user_sources"
+    # Synthetic first_source for users who existed before deep-link tracking.
+    BEFORE_TRACKING_SOURCE = "before_tracking"
+    # Bare /start without ?start= payload (opened via @username / menu).
+    DIRECT_SOURCE = "direct"
 
     def __init__(self, **kwargs):
         from src.export import SheetExporter
@@ -241,12 +245,20 @@ class App:
         user_id: int,
         source: str,
         username: Optional[str] = None,
+        *,
+        count_as_click: bool = True,
     ) -> Optional[str]:
         """
-        Persist deep-link start payload for attribution.
+        Persist acquisition source for a user.
 
-        Keeps first_source (immutable) and last_source (updated each start),
-        plus a short history list. Also writes an event_logs entry.
+        - first_source is immutable once set (original acquisition channel)
+        - last_source updates on every tracked click
+        - history keeps recent clicks (up to 100) when count_as_click=True
+        - every click is also written to event_logs (type start_source)
+
+        Synthetic sources:
+        - before_tracking — backfilled for users known before attribution existed
+        - direct — bare /start without a deep-link payload
         """
         payload = self.normalize_start_payload(source)
         if not payload or user_id is None:
@@ -255,44 +267,103 @@ class App:
         now = datetime.now().isoformat()
         existing = await self.user_sources.find_one({"user_id": user_id})
         history_entry = {"source": payload, "at": now}
+        is_first = existing is None
 
         if existing:
-            await self.user_sources.update_one(
-                {"user_id": user_id},
-                {
-                    "$set": {
-                        "last_source": payload,
-                        "last_source_at": now,
-                        "username": username,
-                    },
-                    "$push": {
-                        "history": {
-                            "$each": [history_entry],
-                            "$slice": -50,
-                        }
-                    },
-                },
-            )
-        else:
-            await self.user_sources.insert_one(
-                {
-                    "user_id": user_id,
-                    "username": username,
-                    "first_source": payload,
-                    "first_source_at": now,
+            update: Dict = {
+                "$set": {
                     "last_source": payload,
                     "last_source_at": now,
-                    "history": [history_entry],
+                    "username": username,
+                },
+            }
+            if count_as_click:
+                update["$push"] = {
+                    "history": {
+                        "$each": [history_entry],
+                        "$slice": -100,
+                    }
                 }
-            )
+                update["$inc"] = {"click_count": 1}
+            await self.user_sources.update_one({"user_id": user_id}, update)
+        else:
+            doc = {
+                "user_id": user_id,
+                "username": username,
+                "first_source": payload,
+                "first_source_at": now,
+                "last_source": payload,
+                "last_source_at": now,
+                "history": [history_entry] if count_as_click else [],
+                "click_count": 1 if count_as_click else 0,
+            }
+            await self.user_sources.insert_one(doc)
 
-        await self.save_event_log(
-            "start_source",
-            {"source": payload, "is_first": existing is None},
-            user_id,
-            username,
-        )
+        if count_as_click:
+            await self.save_event_log(
+                "start_source",
+                {
+                    "source": payload,
+                    "is_first": is_first,
+                    "first_source": (
+                        payload if is_first else (existing or {}).get("first_source")
+                    ),
+                },
+                user_id,
+                username,
+            )
         return payload
+
+    async def get_source_attribution_stats(self) -> Dict[str, Any]:
+        """Aggregate campaign deep-link stats for admin display."""
+        total_users = await self.user_sources.count_documents({})
+        total_clicks_cursor = self.user_sources.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": None,
+                        "clicks": {"$sum": {"$ifNull": ["$click_count", 0]}},
+                    }
+                }
+            ]
+        )
+        total_clicks_rows = await total_clicks_cursor.to_list(length=1)
+        total_clicks = total_clicks_rows[0]["clicks"] if total_clicks_rows else 0
+
+        async def _count_by(field: str) -> List[Dict]:
+            cursor = self.user_sources.aggregate(
+                [
+                    {"$group": {"_id": f"${field}", "count": {"$sum": 1}}},
+                    {"$sort": {"count": -1}},
+                ]
+            )
+            return await cursor.to_list(length=None)
+
+        first_sources = await _count_by("first_source")
+        last_sources = await _count_by("last_source")
+
+        clicks_by_source_cursor = self.user_sources.aggregate(
+            [
+                {"$unwind": {"path": "$history", "preserveNullAndEmptyArrays": False}},
+                {"$group": {"_id": "$history.source", "clicks": {"$sum": 1}}},
+                {"$sort": {"clicks": -1}},
+            ]
+        )
+        clicks_by_source = await clicks_by_source_cursor.to_list(length=None)
+
+        recent_cursor = self.event_logs.find({"event_type": "start_source"}).sort(
+            "timestamp", -1
+        )
+        recent = await recent_cursor.to_list(length=15)
+
+        return {
+            "total_users": total_users,
+            "total_clicks": total_clicks,
+            "first_sources": first_sources,
+            "last_sources": last_sources,
+            "clicks_by_source": clicks_by_source,
+            "recent": recent,
+        }
 
     # ---- Event methods ----
 

--- a/src/migrations.py
+++ b/src/migrations.py
@@ -467,3 +467,53 @@ async def bump_moscow_spb_base_price(app):
     )
     if spb_result.modified_count > 0:
         logger.info("Bumped SPb base price: 1000 → 1500.")
+
+
+# ============================================================
+# Migration: Seed first_source=before_tracking for known users
+# ============================================================
+@migration("007_backfill_before_tracking_sources")
+async def backfill_before_tracking_sources(app):
+    """Mark every known Telegram user with first_source=before_tracking if missing.
+
+    Users who already interacted with the bot before deep-link attribution
+    must keep a stable original source so later campaign clicks only update
+    last_source + history, never overwrite first_source.
+    """
+    source = app.BEFORE_TRACKING_SOURCE
+    now = datetime.now().isoformat()
+
+    active_ids = set(await app.collection.distinct("user_id"))
+    deleted_ids = set(await app.deleted_users.distinct("user_id"))
+    all_ids = {uid for uid in (active_ids | deleted_ids) if uid is not None}
+    already = set(await app.user_sources.distinct("user_id"))
+    missing = sorted(all_ids - already)
+
+    if not missing:
+        logger.info("before_tracking backfill: nothing to seed.")
+        return
+
+    docs = [
+        {
+            "user_id": uid,
+            "username": None,
+            "first_source": source,
+            "first_source_at": now,
+            "last_source": source,
+            "last_source_at": now,
+            "history": [],
+            "click_count": 0,
+            "seeded": "before_tracking_backfill",
+        }
+        for uid in missing
+    ]
+    # insert_many in chunks to avoid oversized batches
+    chunk = 500
+    inserted = 0
+    for i in range(0, len(docs), chunk):
+        result = await app.user_sources.insert_many(docs[i : i + chunk])
+        inserted += len(result.inserted_ids)
+    logger.info(
+        f"before_tracking backfill: seeded {inserted} users "
+        f"(known={len(all_ids)}, already_tracked={len(already)})."
+    )

--- a/src/router.py
+++ b/src/router.py
@@ -2000,13 +2000,27 @@ async def start_handler(message: Message, state: FSMContext, app: App):
             message.from_user.id,
             message.from_user.username,
         )
+        # Attribution: campaign deep links count as clicks; bare /start is "direct"
+        # and only sets first_source if the user has no row yet (no history spam).
         if start_payload:
             await app.record_start_source(
                 message.from_user.id,
                 start_payload,
                 username=message.from_user.username,
+                count_as_click=True,
             )
             await state.update_data(start_source=start_payload)
+        else:
+            existing_source = await app.user_sources.find_one(
+                {"user_id": message.from_user.id}
+            )
+            if existing_source is None:
+                await app.record_start_source(
+                    message.from_user.id,
+                    App.DIRECT_SOURCE,
+                    username=message.from_user.username,
+                    count_as_click=False,
+                )
 
     if is_admin(message.from_user):
         result = await admin_handler(message, state, app=app)

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -71,6 +71,7 @@ _ADMIN_SUBMENUS = {
             "view_year_stats": "По годам выпуска",
             "five_year_stats": "По пятилеткам выпуска",
             "payment_stats": "Диаграмма оплат",
+            "source_stats": "Источники (deep links / кампании)",
         },
     ),
 }
@@ -94,6 +95,7 @@ async def _dispatch_admin_action(
         show_five_year_stats,
         show_payment_stats,
         show_simple_stats,
+        show_source_stats,
         show_stats,
         show_year_stats,
     )
@@ -128,6 +130,8 @@ async def _dispatch_admin_action(
         await show_five_year_stats(message, app=app)
     elif response == "payment_stats":
         await show_payment_stats(message, app=app)
+    elif response == "source_stats":
+        await show_source_stats(message, app=app)
 
 
 async def admin_handler(message: Message, state: FSMContext, app: App):

--- a/src/routers/stats.py
+++ b/src/routers/stats.py
@@ -1077,3 +1077,69 @@ async def show_payment_stats(message: Message, app: App):
         BufferedInputFile(buf.getvalue(), filename="payment_stats.png"),
         caption=caption,
     )
+
+
+def _format_source_counts(rows: list, *, value_key: str = "count") -> str:
+    if not rows:
+        return "  (нет данных)\n"
+    lines = []
+    for row in rows:
+        label = row.get("_id") or "—"
+        lines.append(f"  • <code>{label}</code>: <b>{row.get(value_key, 0)}</b>")
+    return "\n".join(lines) + "\n"
+
+
+def _format_recent_source_clicks(recent: list) -> str:
+    if not recent:
+        return "  (пока нет кликов)\n"
+    lines = []
+    for entry in recent:
+        data = entry.get("data") or {}
+        source = data.get("source", "?")
+        uid = entry.get("user_id", "?")
+        uname = entry.get("username") or ""
+        who = f"@{uname}" if uname else str(uid)
+        ts = (entry.get("timestamp") or "")[:19]
+        first_flag = "🆕 " if data.get("is_first") else ""
+        lines.append(f"  • {ts} {first_flag}<code>{source}</code> — {who}")
+    return "\n".join(lines) + "\n"
+
+
+@commands_menu.add_command(
+    "source_stats",
+    "Статистика источников (deep links)",
+    visibility=Visibility.ADMIN_ONLY,
+)
+@router.message(Command("source_stats"), AdminFilter())
+async def show_source_stats(message: Message, app: App):
+    """Campaign / deep-link attribution: first source, last source, all clicks."""
+    stats = await app.get_source_attribution_stats()
+
+    text = "<b>🔗 Источники трафика (deep links)</b>\n\n"
+    text += f"👥 Пользователей с атрибуцией: <b>{stats['total_users']}</b>\n"
+    text += f"🖱 Всего кликов (history): <b>{stats['total_clicks']}</b>\n\n"
+
+    text += "<b>1) Первый источник (first_source)</b>\n"
+    text += "<i>Оригинальный канал. Не меняется. "
+    text += (
+        f"<code>{App.BEFORE_TRACKING_SOURCE}</code> = были в базе до трекинга.</i>\n"
+    )
+    text += _format_source_counts(stats["first_sources"])
+    text += "\n"
+
+    text += "<b>2) Последний источник (last_source)</b>\n"
+    text += _format_source_counts(stats["last_sources"])
+    text += "\n"
+
+    text += "<b>3) Все клики по кампаниям (history)</b>\n"
+    text += _format_source_counts(stats["clicks_by_source"], value_key="clicks")
+    text += "\n"
+
+    text += "<b>Последние клики</b>\n"
+    text += _format_recent_source_clicks(stats["recent"])
+    text += (
+        "\nСсылки: <code>t.me/&lt;bot&gt;?start=email_campaign</code>\n"
+        "Команда: /source_stats"
+    )
+
+    await send_safe(message.chat.id, text)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -38,6 +38,10 @@ def mock_app():
     mock_app.log_registration_completed = AsyncMock()
     mock_app.save_event_log = AsyncMock()
     mock_app.record_start_source = AsyncMock(return_value=None)
+    mock_app.user_sources = MagicMock()
+    mock_app.user_sources.find_one = AsyncMock(return_value={"user_id": 12345})
+    mock_app.BEFORE_TRACKING_SOURCE = "before_tracking"
+    mock_app.DIRECT_SOURCE = "direct"
     yield mock_app
 
 

--- a/tests/test_start_source.py
+++ b/tests/test_start_source.py
@@ -61,6 +61,7 @@ async def test_record_start_source_first_and_last():
     inserted = sources.insert_one.await_args.args[0]
     assert inserted["first_source"] == "email_campaign"
     assert inserted["last_source"] == "email_campaign"
+    assert inserted["click_count"] == 1
     assert inserted["user_id"] == 42
 
     sources.find_one = AsyncMock(
@@ -75,8 +76,96 @@ async def test_record_start_source_first_and_last():
     sources.update_one.assert_awaited_once()
     update = sources.update_one.await_args.args[1]
     assert update["$set"]["last_source"] == "group_chat"
-    assert update["$set"]["first_source"] if False else True  # first not in $set
     assert "first_source" not in update["$set"]
+    assert update["$inc"]["click_count"] == 1
+    assert update["$push"]["history"]["$each"][0]["source"] == "group_chat"
+
+
+@pytest.mark.asyncio
+async def test_before_tracking_user_keeps_first_on_campaign_click():
+    app = App.__new__(App)
+    sources = MagicMock()
+    sources.find_one = AsyncMock(
+        return_value={
+            "user_id": 7,
+            "first_source": App.BEFORE_TRACKING_SOURCE,
+            "last_source": App.BEFORE_TRACKING_SOURCE,
+            "history": [],
+            "click_count": 0,
+        }
+    )
+    sources.update_one = AsyncMock()
+    sources.insert_one = AsyncMock()
+    app._user_sources = sources
+    app.save_event_log = AsyncMock()
+
+    result = await App.record_start_source(app, 7, "email_campaign", username="old")
+    assert result == "email_campaign"
+    sources.insert_one.assert_not_called()
+    update = sources.update_one.await_args.args[1]
+    assert update["$set"]["last_source"] == "email_campaign"
+    assert "first_source" not in update["$set"]
+    log = app.save_event_log.await_args
+    assert log.args[0] == "start_source"
+    assert log.args[1]["first_source"] == App.BEFORE_TRACKING_SOURCE
+    assert log.args[1]["is_first"] is False
+
+
+@pytest.mark.asyncio
+async def test_direct_start_without_click_does_not_inflate_history():
+    app = App.__new__(App)
+    sources = MagicMock()
+    sources.find_one = AsyncMock(return_value=None)
+    sources.insert_one = AsyncMock()
+    app._user_sources = sources
+    app.save_event_log = AsyncMock()
+
+    await App.record_start_source(
+        app, 9, App.DIRECT_SOURCE, username="x", count_as_click=False
+    )
+    doc = sources.insert_one.await_args.args[0]
+    assert doc["first_source"] == "direct"
+    assert doc["history"] == []
+    assert doc["click_count"] == 0
+    app.save_event_log.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_source_attribution_stats_shape():
+    app = App.__new__(App)
+    sources = MagicMock()
+    sources.count_documents = AsyncMock(return_value=3)
+
+    def aggregate(pipeline):
+        cursor = MagicMock()
+        pipeline_str = str(pipeline)
+        if "history" in pipeline_str and "$unwind" in pipeline_str:
+            cursor.to_list = AsyncMock(
+                return_value=[{"_id": "email_campaign", "clicks": 5}]
+            )
+        elif "click_count" in pipeline_str:
+            cursor.to_list = AsyncMock(return_value=[{"_id": None, "clicks": 5}])
+        else:
+            cursor.to_list = AsyncMock(
+                return_value=[{"_id": "before_tracking", "count": 2}]
+            )
+        return cursor
+
+    sources.aggregate = MagicMock(side_effect=aggregate)
+    app._user_sources = sources
+
+    logs = MagicMock()
+    logs.find = MagicMock(
+        return_value=MagicMock(
+            sort=MagicMock(return_value=MagicMock(to_list=AsyncMock(return_value=[])))
+        )
+    )
+    app._event_logs = logs
+
+    stats = await App.get_source_attribution_stats(app)
+    assert stats["total_users"] == 3
+    assert stats["total_clicks"] == 5
+    assert stats["clicks_by_source"][0]["_id"] == "email_campaign"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Admin **`/source_stats`** (+ menu): first_source, last_source, all clicks by campaign, recent clicks
- Migration seeds every known user with `first_source=before_tracking` (immutable original)
- Every deep-link `/start payload` appends history + increments `click_count`; first_source never overwritten
- Bare `/start` sets `direct` only for brand-new users (no history spam)
- Already-registered users clicking a campaign: **no re-registration**; only attribution updates

## Test plan
- [x] 622 tests passed
- [ ] After deploy: `/source_stats` shows before_tracking cohort
- [ ] Click `?start=email_campaign` as existing user → last_source updates, first stays before_tracking
- [ ] Existing registration still opens management flow, not a second signup