### PR TITLE
Backfill utm fields for campaign stats

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -332,6 +332,21 @@ class App:
         }
 
         if existing:
+            # Heal rows created before structured utm_* fields existed.
+            if not existing.get("first_utm_source"):
+                first_attrs = (
+                    self.parse_start_attribution(existing.get("first_source")) or {}
+                )
+                if first_attrs.get("utm_source"):
+                    last_fields.setdefault(
+                        "first_utm_source", first_attrs["utm_source"]
+                    )
+                    last_fields.setdefault(
+                        "first_utm_campaign", first_attrs.get("utm_campaign")
+                    )
+                    last_fields.setdefault(
+                        "first_utm_content", first_attrs.get("utm_content")
+                    )
             update: Dict = {"$set": last_fields}
             if count_as_click:
                 update["$push"] = {

--- a/src/migrations.py
+++ b/src/migrations.py
@@ -523,3 +523,46 @@ async def backfill_before_tracking_sources(app):
         f"before_tracking backfill: seeded {inserted} users "
         f"(known={len(all_ids)}, already_tracked={len(already)})."
     )
+
+
+# ============================================================
+# Migration: Fill utm_* fields on rows created before structured parse
+# ============================================================
+@migration("008_backfill_utm_fields_from_raw")
+async def backfill_utm_fields_from_raw(app):
+    """Populate first/last utm_* from raw first_source/last_source when missing.
+
+    Migration 007 originally wrote only first_source/last_source. Later code
+    expects first_utm_source / first_utm_campaign for stats. Re-parse raw
+    payloads (including synthetic before_tracking / direct).
+    """
+    cursor = app.user_sources.find(
+        {
+            "$or": [
+                {"first_utm_source": {"$exists": False}},
+                {"first_utm_source": None},
+                {"last_utm_source": {"$exists": False}},
+                {"last_utm_source": None},
+            ]
+        }
+    )
+    rows = await cursor.to_list(length=None)
+    fixed = 0
+    for row in rows:
+        updates = {}
+        if not row.get("first_utm_source"):
+            attrs = app.parse_start_attribution(row.get("first_source")) or {}
+            if attrs.get("utm_source"):
+                updates["first_utm_source"] = attrs["utm_source"]
+                updates["first_utm_campaign"] = attrs.get("utm_campaign")
+                updates["first_utm_content"] = attrs.get("utm_content")
+        if not row.get("last_utm_source"):
+            attrs = app.parse_start_attribution(row.get("last_source")) or {}
+            if attrs.get("utm_source"):
+                updates["last_utm_source"] = attrs["utm_source"]
+                updates["last_utm_campaign"] = attrs.get("utm_campaign")
+                updates["last_utm_content"] = attrs.get("utm_content")
+        if updates:
+            await app.user_sources.update_one({"_id": row["_id"]}, {"$set": updates})
+            fixed += 1
+    logger.info(f"utm field backfill: updated {fixed} of {len(rows)} candidate rows.")


### PR DESCRIPTION
Fixes empty first_utm_source in /source_stats after before_tracking seed without structured fields.