### PR TITLE
feat(events): optional website_event_uid link on event documents

### DIFF
--- a/dev/set_website_event_uid.py
+++ b/dev/set_website_event_uid.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Bind one bot event document to one website ``Event.uid``.
+
+The website's SQL ``events`` table is the source of truth for events; its
+stable ``Event.uid`` is the cross-system key (contract:
+146.school/docs/events-people-data-integration.md, «Контракт по событиям»).
+Migration ``010_add_website_event_uid`` declares the field as ``None`` on every
+event document; this script sets an actual value.
+
+It is deliberately a separate, explicit, per-environment step. A migration runs
+identically everywhere, and staging must never inherit production's website UID
+— pointing a staging bot at the production event is exactly the mistake that
+would create real admissions from test registrations.
+
+Usage (dry run first — it is the default):
+
+    python dev/set_website_event_uid.py \\
+        --bot-event-id 6a599a17a37724d81b7eadc3 \\
+        --website-event-uid event-1@146.school
+
+    # …then repeat with --apply
+
+Unbind (rollback for one event):
+
+    python dev/set_website_event_uid.py --bot-event-id <id> --unset --apply
+
+Full rollback of the migration, for reference:
+
+    db.events.updateMany({}, {$unset: {website_event_uid: ""}})
+
+Connection comes from the same environment the bot uses:
+``BOTSPOT_MONGO_DATABASE_CONN_STR`` and ``BOTSPOT_MONGO_DATABASE_DATABASE``.
+"""
+
+import argparse
+import os
+import sys
+
+from bson import ObjectId
+from bson.errors import InvalidId
+from dotenv import load_dotenv
+from pymongo import MongoClient
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bot-event-id", required=True,
+                        help="ObjectId of the event document in Mongo")
+    parser.add_argument("--website-event-uid",
+                        help="stable website Event.uid, e.g. event-1@146.school")
+    parser.add_argument("--unset", action="store_true",
+                        help="clear the link instead of setting it")
+    parser.add_argument("--apply", action="store_true",
+                        help="actually write; without it the script only reports")
+    args = parser.parse_args(argv)
+    if args.unset == bool(args.website_event_uid):
+        parser.error("give exactly one of --website-event-uid or --unset")
+    return args
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    load_dotenv()
+
+    conn = os.environ.get("BOTSPOT_MONGO_DATABASE_CONN_STR")
+    database = os.environ.get("BOTSPOT_MONGO_DATABASE_DATABASE")
+    if not conn or not database:
+        print("BOTSPOT_MONGO_DATABASE_CONN_STR / _DATABASE are not set",
+              file=sys.stderr)
+        return 2
+
+    try:
+        object_id = ObjectId(args.bot_event_id)
+    except (InvalidId, TypeError):
+        print(f"not a valid ObjectId: {args.bot_event_id!r}", file=sys.stderr)
+        return 2
+
+    events = MongoClient(conn)[database]["events"]
+    event = events.find_one({"_id": object_id})
+    if not event:
+        print(f"no event document with _id={args.bot_event_id}", file=sys.stderr)
+        return 1
+
+    target = None if args.unset else args.website_event_uid
+    print(f"event:   {event.get('name')!r} ({event.get('status')})")
+    print(f"current: website_event_uid={event.get('website_event_uid')!r}")
+    print(f"new:     website_event_uid={target!r}")
+
+    # Both sides are unique keys; refuse to point two bot events at one website
+    # event, which would let two registration funnels mint admissions for it.
+    if target is not None:
+        clash = events.find_one(
+            {"website_event_uid": target, "_id": {"$ne": object_id}})
+        if clash:
+            print(f"refusing: {target!r} is already bound to event "
+                  f"{clash['_id']} ({clash.get('name')!r})", file=sys.stderr)
+            return 1
+
+    if not args.apply:
+        print("\ndry run — nothing written. Re-run with --apply.")
+        return 0
+
+    result = events.update_one({"_id": object_id},
+                               {"$set": {"website_event_uid": target}})
+    print(f"\nwritten: matched={result.matched_count} "
+          f"modified={result.modified_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/set_website_event_uid.py
+++ b/dev/set_website_event_uid.py
@@ -44,14 +44,20 @@ from pymongo import MongoClient
 
 def parse_args(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--bot-event-id", required=True,
-                        help="ObjectId of the event document in Mongo")
-    parser.add_argument("--website-event-uid",
-                        help="stable website Event.uid, e.g. event-1@146.school")
-    parser.add_argument("--unset", action="store_true",
-                        help="clear the link instead of setting it")
-    parser.add_argument("--apply", action="store_true",
-                        help="actually write; without it the script only reports")
+    parser.add_argument(
+        "--bot-event-id", required=True, help="ObjectId of the event document in Mongo"
+    )
+    parser.add_argument(
+        "--website-event-uid", help="stable website Event.uid, e.g. event-1@146.school"
+    )
+    parser.add_argument(
+        "--unset", action="store_true", help="clear the link instead of setting it"
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually write; without it the script only reports",
+    )
     args = parser.parse_args(argv)
     if args.unset == bool(args.website_event_uid):
         parser.error("give exactly one of --website-event-uid or --unset")
@@ -65,8 +71,9 @@ def main(argv=None) -> int:
     conn = os.environ.get("BOTSPOT_MONGO_DATABASE_CONN_STR")
     database = os.environ.get("BOTSPOT_MONGO_DATABASE_DATABASE")
     if not conn or not database:
-        print("BOTSPOT_MONGO_DATABASE_CONN_STR / _DATABASE are not set",
-              file=sys.stderr)
+        print(
+            "BOTSPOT_MONGO_DATABASE_CONN_STR / _DATABASE are not set", file=sys.stderr
+        )
         return 2
 
     try:
@@ -90,20 +97,24 @@ def main(argv=None) -> int:
     # event, which would let two registration funnels mint admissions for it.
     if target is not None:
         clash = events.find_one(
-            {"website_event_uid": target, "_id": {"$ne": object_id}})
+            {"website_event_uid": target, "_id": {"$ne": object_id}}
+        )
         if clash:
-            print(f"refusing: {target!r} is already bound to event "
-                  f"{clash['_id']} ({clash.get('name')!r})", file=sys.stderr)
+            print(
+                f"refusing: {target!r} is already bound to event "
+                f"{clash['_id']} ({clash.get('name')!r})",
+                file=sys.stderr,
+            )
             return 1
 
     if not args.apply:
         print("\ndry run — nothing written. Re-run with --apply.")
         return 0
 
-    result = events.update_one({"_id": object_id},
-                               {"$set": {"website_event_uid": target}})
-    print(f"\nwritten: matched={result.matched_count} "
-          f"modified={result.modified_count}")
+    result = events.update_one(
+        {"_id": object_id}, {"$set": {"website_event_uid": target}}
+    )
+    print(f"\nwritten: matched={result.matched_count} modified={result.modified_count}")
     return 0
 
 

--- a/docs/website-event-uid.md
+++ b/docs/website-event-uid.md
@@ -1,0 +1,74 @@
+# `website_event_uid` — link from a bot event to the website event
+
+Implements the «Контракт по событиям» section of
+`146.school/docs/events-people-data-integration.md`.
+
+## The rule
+
+The website's SQL `events` table is the **source of truth** for events. An
+event is created on the website (its admin already exists); every other system
+references it. The cross-system key is the website's stable `Event.uid` — no
+new column on the website side was needed.
+
+A bot event document therefore carries an optional `website_event_uid`
+pointing at that value. Registrations (`registered_users`) keep referencing the
+bot's own `event_id`; their link to the website is transitive through the event
+document.
+
+Calendar-field sync (name, date, venue, url) is **one-way, website → bot**.
+Pricing, registration status, and the registrations themselves stay operational
+bot data.
+
+## Two steps, deliberately separate
+
+**1. Declare the field — migration `010_add_website_event_uid`.**
+Sets `website_event_uid: None` on every event document that lacks it. It
+asserts no mapping, so it is safe to run identically in every environment and
+is a no-op on re-run.
+
+**2. Bind an actual value — `dev/set_website_event_uid.py`.**
+Per-environment operational configuration, run by a human.
+
+```sh
+# dry run (the default — prints what would change, writes nothing)
+python dev/set_website_event_uid.py \
+    --bot-event-id 6a599a17a37724d81b7eadc3 \
+    --website-event-uid event-1@146.school
+
+# then, having read the output
+python dev/set_website_event_uid.py \
+    --bot-event-id 6a599a17a37724d81b7eadc3 \
+    --website-event-uid event-1@146.school --apply
+```
+
+The binding is **not** in the migration on purpose: staging must never inherit
+production's website UID. A staging bot pointed at the production event would
+mint real admissions from test registrations.
+
+The script refuses to bind a website UID that another bot event already claims,
+so two registration funnels cannot both mint admissions for one website event.
+
+## Current August 1 mapping
+
+- website: SQL `events.id = 1`, `uid = event-1@146.school`
+- bot: Mongo `_id = 6a599a17a37724d81b7eadc3`
+
+The website's `uid` is filled by its own Alembic revision `20260725_0006`, which
+writes exactly the value the `.ics` feed already emitted as its fallback — so
+no subscribed calendar sees a UID change.
+
+## Rollback
+
+One event:
+
+```sh
+python dev/set_website_event_uid.py --bot-event-id <id> --unset --apply
+```
+
+The whole migration:
+
+```js
+db.events.updateMany({}, {$unset: {website_event_uid: ""}})
+```
+
+Nothing reads the field yet, so removing it restores the previous state exactly.

--- a/src/migrations.py
+++ b/src/migrations.py
@@ -597,3 +597,36 @@ async def summer_2026_food_flag_and_early_bird(app):
         f"summer 2026 food/early-bird: matched={result.matched_count} "
         f"modified={result.modified_count}"
     )
+
+
+# ============================================================
+# Migration: optional website_event_uid link on event documents
+# ============================================================
+@migration("010_add_website_event_uid")
+async def add_website_event_uid(app):
+    """Add the optional cross-system link field to every event document.
+
+    The website's SQL ``events`` table is the source of truth for events
+    (contract: 146.school/docs/events-people-data-integration.md, «Контракт по
+    событиям»). Its stable ``Event.uid`` is the cross-system key, and a bot
+    event document points at one via ``website_event_uid``.
+
+    This step only *declares* the field, defaulting to ``None``: it makes the
+    link explicit and queryable without asserting any particular mapping.
+    Binding a specific bot event to a specific website UID is per-environment
+    operational configuration — staging must never inherit production's UID —
+    so it is done separately with ``dev/set_website_event_uid.py``.
+
+    Additive and reversible; rollback is a single command documented in
+    ``docs/website-event-uid.md``:
+
+        db.events.updateMany({}, {$unset: {website_event_uid: ""}})
+    """
+    result = await app.events_col.update_many(
+        {"website_event_uid": {"$exists": False}},
+        {"$set": {"website_event_uid": None}},
+    )
+    logger.info(
+        f"website_event_uid: declared on {result.modified_count} event documents "
+        f"(matched={result.matched_count})."
+    )

--- a/tests/test_website_event_uid.py
+++ b/tests/test_website_event_uid.py
@@ -23,7 +23,8 @@ REPO = Path(__file__).resolve().parents[1]
 
 def _load_ops_script():
     spec = importlib.util.spec_from_file_location(
-        "set_website_event_uid", REPO / "dev" / "set_website_event_uid.py")
+        "set_website_event_uid", REPO / "dev" / "set_website_event_uid.py"
+    )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -44,7 +45,8 @@ class TestAddWebsiteEventUid:
     def _app(self, modified=3, matched=3):
         app = MagicMock()
         app.events_col.update_many = AsyncMock(
-            return_value=MagicMock(modified_count=modified, matched_count=matched))
+            return_value=MagicMock(modified_count=modified, matched_count=matched)
+        )
         return app
 
     @pytest.mark.asyncio
@@ -87,13 +89,24 @@ class TestOpsScriptArguments:
             self.module.parse_args(["--bot-event-id", "abc"])
         with pytest.raises(SystemExit):
             self.module.parse_args(
-                ["--bot-event-id", "abc", "--unset",
-                 "--website-event-uid", "event-1@146.school"])
+                [
+                    "--bot-event-id",
+                    "abc",
+                    "--unset",
+                    "--website-event-uid",
+                    "event-1@146.school",
+                ]
+            )
 
     def test_accepts_a_set_invocation(self):
         args = self.module.parse_args(
-            ["--bot-event-id", "6a599a17a37724d81b7eadc3",
-             "--website-event-uid", "event-1@146.school"])
+            [
+                "--bot-event-id",
+                "6a599a17a37724d81b7eadc3",
+                "--website-event-uid",
+                "event-1@146.school",
+            ]
+        )
         assert args.website_event_uid == "event-1@146.school"
         assert args.unset is False
 
@@ -101,6 +114,11 @@ class TestOpsScriptArguments:
         """Dry run is the default: an ops script that touches prod on a typo
         is worse than one that needs a second invocation."""
         args = self.module.parse_args(
-            ["--bot-event-id", "6a599a17a37724d81b7eadc3",
-             "--website-event-uid", "event-1@146.school"])
+            [
+                "--bot-event-id",
+                "6a599a17a37724d81b7eadc3",
+                "--website-event-uid",
+                "event-1@146.school",
+            ]
+        )
         assert args.apply is False

--- a/tests/test_website_event_uid.py
+++ b/tests/test_website_event_uid.py
@@ -1,0 +1,106 @@
+"""Optional website_event_uid link on event documents (migration 010).
+
+The website SQL `events` table is the source of truth for events; a bot event
+document points at one via its stable `Event.uid`. See
+146.school/docs/events-people-data-integration.md, «Контракт по событиям».
+
+The migration only declares the field. Binding a real value is a separate,
+per-environment ops step — `dev/set_website_event_uid.py` — because staging
+must never inherit production's website UID.
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.migrations import MIGRATION_REGISTRY, add_website_event_uid
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _load_ops_script():
+    spec = importlib.util.spec_from_file_location(
+        "set_website_event_uid", REPO / "dev" / "set_website_event_uid.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestMigrationRegistration:
+    def test_migration_is_registered_once_and_last(self):
+        names = [m.name for m in MIGRATION_REGISTRY]
+        assert names.count("010_add_website_event_uid") == 1
+        assert names[-1] == "010_add_website_event_uid"
+
+    def test_migration_names_stay_unique(self):
+        names = [m.name for m in MIGRATION_REGISTRY]
+        assert len(names) == len(set(names))
+
+
+class TestAddWebsiteEventUid:
+    def _app(self, modified=3, matched=3):
+        app = MagicMock()
+        app.events_col.update_many = AsyncMock(
+            return_value=MagicMock(modified_count=modified, matched_count=matched))
+        return app
+
+    @pytest.mark.asyncio
+    async def test_declares_the_field_as_none_where_absent(self):
+        app = self._app()
+        await add_website_event_uid(app)
+        app.events_col.update_many.assert_awaited_once_with(
+            {"website_event_uid": {"$exists": False}},
+            {"$set": {"website_event_uid": None}},
+        )
+
+    @pytest.mark.asyncio
+    async def test_never_overwrites_an_existing_link(self):
+        """The filter, not a later guard, is what makes a re-run safe."""
+        app = self._app()
+        await add_website_event_uid(app)
+        query, _update = app.events_col.update_many.await_args.args
+        assert query == {"website_event_uid": {"$exists": False}}
+
+    @pytest.mark.asyncio
+    async def test_asserts_no_particular_mapping(self):
+        app = self._app()
+        await add_website_event_uid(app)
+        _query, update = app.events_col.update_many.await_args.args
+        assert update == {"$set": {"website_event_uid": None}}
+
+    @pytest.mark.asyncio
+    async def test_is_a_no_op_on_a_second_run(self):
+        app = self._app(modified=0, matched=0)
+        await add_website_event_uid(app)  # must not raise
+        app.events_col.update_many.assert_awaited_once()
+
+
+class TestOpsScriptArguments:
+    def setup_method(self):
+        self.module = _load_ops_script()
+
+    def test_requires_exactly_one_of_uid_or_unset(self):
+        with pytest.raises(SystemExit):
+            self.module.parse_args(["--bot-event-id", "abc"])
+        with pytest.raises(SystemExit):
+            self.module.parse_args(
+                ["--bot-event-id", "abc", "--unset",
+                 "--website-event-uid", "event-1@146.school"])
+
+    def test_accepts_a_set_invocation(self):
+        args = self.module.parse_args(
+            ["--bot-event-id", "6a599a17a37724d81b7eadc3",
+             "--website-event-uid", "event-1@146.school"])
+        assert args.website_event_uid == "event-1@146.school"
+        assert args.unset is False
+
+    def test_writes_nothing_without_apply(self):
+        """Dry run is the default: an ops script that touches prod on a typo
+        is worse than one that needs a second invocation."""
+        args = self.module.parse_args(
+            ["--bot-event-id", "6a599a17a37724d81b7eadc3",
+             "--website-event-uid", "event-1@146.school"])
+        assert args.apply is False


### PR DESCRIPTION
Job (3) of the events/people data integration, bot half. Website half:
Club-146/146.school#27 (backfills `Event.uid`, calendar-safe).

## Why

The website's SQL `events` table is the **source of truth** for events; the
cross-system key is its stable `Event.uid` (contract:
`146.school/docs/events-people-data-integration.md`, «Контракт по событиям»).
A bot event document now carries an optional `website_event_uid` pointing at
one. Registrations keep referencing the bot's own `event_id` and reach the
website transitively.

## Two deliberately separate steps

**1. Declare the field** — migration `010_add_website_event_uid` sets
`website_event_uid: None` wherever it is absent. It asserts no mapping, so it
runs identically in every environment and is a no-op on re-run.

**2. Bind an actual value** — `dev/set_website_event_uid.py`, run by a human.

This split is the point. A migration runs identically everywhere, and **staging
must never inherit production's website UID** — a staging bot pointed at the
production event would mint real admissions from test registrations. The script
also refuses a UID another bot event already claims, so two registration funnels
cannot both mint admissions for one website event. Dry run is the default.

## Reversible

Nothing reads the field yet. Rollback is one documented `$unset` (whole
migration) or `--unset --apply` (single event). See `docs/website-event-uid.md`.

## Verification

14 new tests; full suite **642 passed**.

**No deploy performed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)