### PR TITLE
release: website calendar read-through (flag off) + payment amount parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,14 +216,10 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# AI instruction files (generated)
-CLAUDE.md
-GEMINI.md
+# Local AI tool state (not shared)
 .cursorrules
-
-# AI instruction files (generated)
 .claude
 
-# AI instruction files (generated)
-AGENTS.md
+# Deprecated AI instruction copies — do not reintroduce
+GEMINI.md
 WARP.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# OpenAI Codex Instructions
+
+Deploy: prod does NOT auto-deploy — merging to `main` ships nothing. Always finish with `make deploy-prod` (or `make release-prod`, which includes it). Cause: prod app is on Coolify `source_id=2` (calmmage GitHub App), not 4 (Club-146), so no push webhook ever arrives; failure is silent, prod just keeps serving the old image. Never tell the user a merge is live — check `deployments/applications/raa8wuc20q0leqf7svr2tj83` and the `Europe/Moscow` line in `src.reminder_scheduler` startup logs. `scripts/coolify-deploy.sh`, `docs/DEPLOY.md`.
+
+Campaign / UTM-like attribution (CRM-ish): Telegram deep links only — `t.me/<bot>?start={source}__{campaign}[__{content}]`. Classic `?utm_*=` on bot URLs does nothing. Parser + store: `App.parse_start_attribution` / `record_start_source` / `user_sources`; /start extract in `router.extract_start_payload`; registration stamps `RegisteredUser.start_source`; admin `/source_stats`. Full note: `docs/start-source-attribution.md`. Outbound mailers (e.g. 146.school event_announce) must put payload in `?start=`, not site UTM.
+
+Imports
+- Always use absolute imports - from repo root
+- Use uv run to ensure imports work
+- Avoid modifying sys.path
+
+Docker compose
+- For projects with interlinked components, include Docker file and a docker-compose.yml
+- Specificaly, that concerns frontend + backend applications or other multi-component projects
+
+Monorepo selective commits:
+
+```bash
+git add -A
+git commit <file1> <file2> <file3> -m "message"
+```
+
+Step 1 stages everything, Step 2 commits only specified files. Does NOT unstage other files, does NOT require stashing.
+
+Alternatives:
+- lazygit: Navigate → Space to stage → `c` to commit
+- PyCharm: Commit window (Cmd+K) → select files → commit
+- GUI tools: GitHub Desktop, GitKraken, Fork
+
+We are writing instructions for a smart user, that can figure everything out, has strong intuition and can easily guess reasonable things, given a few hints.
+
+Therefore:
+1) NO HEADERS
+2) BE EXTREMELY CONCISE, JUST MENTION KEY FUNCTIONS / FOLDERS BY NAME, DO NOT GO INTO VERBOSE DETAILS OR YAPPING
+
+Preserve original text and phrasing provided by the user in chats as much as possible.
+
+Makefile - add after prototype, 1-2 essential commands per component max
+
+Minimal prototyping flow
+For ~/calmmage/experiments/prototypes folder
+- Before implementing a new feature - write a minimal working standalone prototype / demo - and test it.
+- After the feature is working - update the existing code with the working code
+
+# Next.js Style (shadcn, v0.dev-inspired)
+
+Build front-ends in Next.js with:
+- App Router, Server Components by default; Client Components only when needed.
+- UI components: use shadcn patterns for UIs.
+
+uv for python:
+- initialize pyproject.toml if missing.
+    - use `fix_repo` alias
+- uv run for execution
+- uv add for dependencies
+
+# Python Libraries
+- pathlib: Filesystem paths with `Path`.
+- dotenv: Load `~/.env` non-secret config. Secrets are in `~/.env.enc` — use `find_env_key()`.
+- httpx: HTTP client (sync/async) with timeouts.
+- use loguru with calmlib.logging.setup_logger() settings - avoid prints
+- typer for CLI, argparse for simple script flags
+- rich: Rich terminal output (tables, colors).
+- pydantic / pydantic_settings - avoid dataclasses and unstructured Dicts
+- fastapi
+- tqdm
+
+- print_exc - use to show full tracebacks
+- avoid excessive try/except nesting or blocks, always handle errors on external level, unless explicitly
+  requested[6_python_libs.md](6_python_libs.md)
+
+- Type safety - use pydantic, type hints
+- Clean patterns - pathlib over os.path, loguru over print
+- Simplicity
+    - Implement minimal necessary functionality
+    - Avoid major refactorings unless explicitly requested
+- Modularity with utils
+    - Avoid nesting as much as possible - create separate service util functions (private - _func)
+    - Avoid code duplication - instead, create reusable utils
+    
+- CLIs with `typer`;
+- Keep `cli.py` colocated under each tool directory.
+- Provide short docstrings and a quick usage example per command.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fix fix-unsafe help run run-debug test mock-website-api release-prod
+.PHONY: check fix fix-unsafe help run run-debug test mock-website-api release-prod deploy-prod deploy-dev
 
 run:
 	uv run python run.py
@@ -29,7 +29,8 @@ fix-unsafe:
 test:
 	uv run pytest tests/ --cov=src --cov-report=term --cov-fail-under=40
 
-# Prod: push dev → PR to main → merge (Coolify auto-deploys). See docs/DEPLOY.md
+# Prod: push dev → PR to main → merge → deploy-prod. See docs/DEPLOY.md
+# Merging to main does NOT deploy on its own — the last step is what ships.
 release-prod:
 	@test "$$(git branch --show-current)" = "dev" || (echo "must be on branch dev"; exit 1)
 	@test -z "$$(git status --porcelain)" || (echo "working tree dirty — commit first"; exit 1)
@@ -45,7 +46,24 @@ release-prod:
 	echo "Merging PR #$$pr …"; \
 	gh pr merge "$$pr" --merge --delete-branch=false
 	@git fetch origin main
-	@echo "OK: main updated. Coolify prod should redeploy from main."
+	@echo "main updated — now deploying (prod does not auto-deploy)…"
+	@$(MAKE) --no-print-directory deploy-prod
+
+# Coolify deploys on new-c.calmmage.com (Petr's personal Hetzner box).
+#
+# Prod does NOT auto-deploy. The prod app is bound to the `calmmage` GitHub App
+# (source_id=2) instead of `Club-146` (source_id=4), so GitHub never delivers a
+# push webhook for this repo to it. On 28 Jul 2026 that left prod 12 days behind
+# `main`, still running the pre-timezone-fix scheduler and blasting every unpaid
+# user at 03:15 MSK. Merging to `main` changes nothing on the server until this
+# runs. Dev is on source_id=4 and does auto-deploy on push to `dev`.
+#
+# Force rebuild: make deploy-prod FORCE=1
+deploy-prod:
+	@./scripts/coolify-deploy.sh prod
+
+deploy-dev:
+	@./scripts/coolify-deploy.sh dev
 
 help:
 	@echo "Available targets:"
@@ -54,5 +72,7 @@ help:
 	@echo "  fix-unsafe        - Auto-fix with unsafe fixes enabled"
 	@echo "  test              - Run tests with coverage"
 	@echo "  mock-website-api  - Local mock of website event-payment internal API"
-	@echo "  release-prod      - push dev → PR → merge to main (Coolify prod)"
+	@echo "  release-prod      - push dev → PR → merge to main → deploy-prod"
+	@echo "  deploy-prod       - Coolify prod redeploy (REQUIRED: main does not auto-deploy)"
+	@echo "  deploy-dev        - Coolify dev redeploy (dev auto-deploys; this is a manual kick)"
 	@echo "  help              - Show this help message"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Build and run with Docker:
 docker-compose up --build
 ```
 
+## Deploy
+
+**Prod does not auto-deploy — merging to `main` ships nothing.** You must deploy:
+
+```bash
+make release-prod   # push dev → PR → merge main → deploy
+make deploy-prod    # deploy only (Coolify prod)
+```
+
+Why, how to verify a deploy actually landed, and the permanent fix:
+[docs/DEPLOY.md](docs/DEPLOY.md).
+
 ## License
 
 This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,16 +1,92 @@
 # Deploy (prod)
 
-Coolify watches **main** (`prod - main - register-146-meetup-2025-bot`). Dev Coolify watches **dev**.
+**Prod does not auto-deploy. Merging to `main` ships nothing — you must run `make deploy-prod`.**
 
 ```text
-work on dev → push dev → PR dev→main → merge
-→ Coolify auto-deploys prod
+work on dev → push dev → PR dev→main → merge → make deploy-prod
 ```
 
-One sweep from a clean `dev` with commits ahead of `main`:
+One sweep from a clean `dev` with commits ahead of `main` (does all of the above,
+deploy included):
 
 ```bash
 make release-prod
 ```
 
-Pay links default to `https://146.school`. Coolify **dev** may set `PAYMENT_SITE_BASE_URL=https://staging.146.school.calmmage.com`.
+Deploy only, without touching git:
+
+```bash
+make deploy-prod            # Coolify prod, branch main
+make deploy-prod FORCE=1    # force rebuild (no cache)
+make deploy-dev             # manual kick for dev; dev also auto-deploys on push
+```
+
+## Why prod does not auto-deploy
+
+Coolify apps (both on `new-c.calmmage.com`, Petr's personal Hetzner box):
+
+| App | Branch | Coolify `source_id` | Auto-deploy |
+|---|---|---|---|
+| `dev - bot - register-146-meetup-2025-bot` | `dev` | 4 — Club-146 GitHub App | yes |
+| `prod - main - register-146-meetup-2025-bot` | `main` | 2 — **calmmage** GitHub App | **no** |
+
+Source 2 is the GitHub App installed for the `calmmage/*` repos. It is not the
+installation that receives pushes for `Club-146/club-146-event-registration-bot`,
+so GitHub never delivers a webhook to the prod app. Dev's recent deployments are
+all `is_webhook=true`; prod's are all manual `force_rebuild=true`.
+
+This is silent. Nothing errors — prod just keeps serving the last image someone
+deployed by hand.
+
+**It bit us on 28 Jul 2026.** The reminder-scheduler timezone fix (`4947aed`,
+PR #69) merged to `main` on 27 Jul. Prod's last build was 26 Jul (`91c3f0e`), so
+prod kept running the old UTC-naive scheduler whose hourly catch-up fired at
+00:15 UTC = **03:15 MSK**, messaging every unpaid registrant in the middle of the
+night. Prod had not auto-deployed since 16 Jul — 12 days.
+
+Permanent fix (not done yet): repoint the prod app to source 4 in the Coolify UI,
+Configuration → Source. Until then `make deploy-prod` is mandatory.
+
+## Verifying a deploy actually landed
+
+`running` in Coolify means the container is up, not that it is up with your code.
+Check the commit and the startup log:
+
+```bash
+# what prod actually built, most recent first
+curl -s -H "Authorization: Bearer $COOLIFY_NEW_TOKEN" \
+  "$COOLIFY_NEW_URL/api/v1/deployments/applications/raa8wuc20q0leqf7svr2tj83?take=3" \
+  | python3 -c 'import json,sys; [print(d["created_at"], d["status"], d["commit"][:9]) for d in json.load(sys.stdin)["deployments"]]'
+
+# is a given commit actually in what is deployed?
+git merge-base --is-ancestor <fix-sha> <deployed-sha> && echo included || echo MISSING
+```
+
+Container log after a good deploy contains:
+
+```text
+src.reminder_scheduler | payment reminder scheduler started
+  (daily 09:00 Europe/Moscow + catch-up :15 hours 9–17 MSK)
+```
+
+If that line says anything other than `Europe/Moscow`, prod is running pre-fix
+code and will send at 03:15 MSK.
+
+Re-deploying is safe against double-sends: delivery sets per-registration flags
+(`payment_reminder_d4_sent` / `_d2_sent`), and those flag names are unchanged
+across versions, so already-notified users are skipped on the next tick.
+
+## Credentials
+
+`scripts/coolify-deploy.sh` takes the token from `$COOLIFY_NEW_TOKEN` (exported
+from `~/.zshrc`), falling back to `CALMMAGE_COOLIFY_NEW_API_KEY` in `~/.env.enc`.
+URL override: `$COOLIFY_NEW_URL` (default `https://new-c.calmmage.com`).
+
+The script preflights the app UUID and refuses unless the repo and branch match —
+a wrong instance or token otherwise returns `404 No resources found`, which reads
+like the app disappeared.
+
+## Env
+
+Pay links default to `https://146.school`. Coolify **dev** may set
+`PAYMENT_SITE_BASE_URL=https://staging.146.school.calmmage.com`.

--- a/docs/paid-ticket-contract.md
+++ b/docs/paid-ticket-contract.md
@@ -200,6 +200,34 @@ confirm JSON shape under production code (see contradiction note below).
 3. **Guest wire payload.** Guests still go over the wire as name + fixed amount
    only. Graduation year/letter are stored on the bot registration for pricing
    and display; expanding website `GuestTerms` is a follow-up.
+
+   **Guest pricing rule — DECIDED 27 Jul 2026 (Petr).** A guest who gives a
+   school year is priced *exactly like a registrant of that year*; a guest with
+   no school year (a «друг») pays the flat guest rate. This side is canonical
+   (`App.calculate_guest_price`) and the website was changed to match.
+
+   It closes a real loophole: the website used to charge every guest a flat
+   `guest_price_fixed`, so a 1995 alum cost 1500 as somebody's guest versus
+   7600 as themselves — a 6100₽ discount for using the guest field.
+
+   **This side needs no code change, but it does need config:**
+   `guest_price_minimum` must be set to the intended flat rate (1500). That one
+   field is both the floor for alum guests and the price for a «друг»; left at
+   0, a «друг» falls through to "the formula for someone who left 15 years ago"
+   (4400 for the Aug 1 config).
+
+   Two details that are easy to get subtly wrong, and are pinned by tests:
+   - free attendee types return 0 **before** the minimum applies, so a teacher
+     brought as a guest is not floored up to 1500.
+   - the minimum floors the *regular* amount and the early-bird discount comes
+     off afterwards, so the final amount can sit below the minimum
+     (1500 - 500 = 1000).
+
+   The agreed numbers live in a table duplicated in both repos:
+   `tests/test_guest_pricing_parity.py` here and
+   `newsite/tests/test_guest_pricing_parity.py` on the website. Change guest
+   pricing in one repo and the other repo's suite fails — deliberately, since
+   the two services share no package.
 4. **Pricing config endpoint — RESOLVED 2026-07-27.** It exists:
    `GET /api/internal/event-configs/by-bot-event/{bot_event_id}` (also
    `by-uid/{website_event_uid}`, a bare list, and a `PUT` for upserts). It

--- a/docs/website-event-uid.md
+++ b/docs/website-event-uid.md
@@ -15,9 +15,36 @@ pointing at that value. Registrations (`registered_users`) keep referencing the
 bot's own `event_id`; their link to the website is transitive through the event
 document.
 
-Calendar-field sync (name, date, venue, url) is **one-way, website → bot**.
-Pricing, registration status, and the registrations themselves stay operational
-bot data.
+Calendar fields (name, date, venue, address) are **read from the website, not
+synced**. There is no copy in Mongo to go stale: `App` reads the website's row
+and overlays it onto an in-memory copy of the event document on every read (see
+`src/website_db.py`). Pricing, registration status, and the registrations
+themselves stay operational bot data.
+
+> **The bot connects to the website's PostgreSQL directly** — decided 28.07.2026
+> by Petr. Earlier notes in this repo said the opposite («a `DATABASE_URL`
+> appearing in this repo means wrong path»); that rule is superseded. Reads go
+> over SQL as the least-privilege `club146_bot_ro` role (SELECT on `events`,
+> `event_registration_configs`, `person_telegram_links` — and nothing else;
+> `people` and `donations` are deliberately ungranted). **Writes** —
+> intents, confirm, revoke — still go through the website's internal HTTP API,
+> which owns idempotency, validation and the audit log.
+>
+> Why read-through rather than a sync job: a sync job copies, a copy can be
+> stale, and the moment both sides can write it needs a conflict rule. On
+> 28.07.2026 the site advertised ул. Встречная while the bot told 46 registrants
+> ул. Самаркандская — two stores, two write paths, nothing reconciling them.
+> Holding no second copy removes the failure mode instead of monitoring it.
+
+Because the website is the owner, the bot's admin **no longer offers** название,
+дата, место or адрес for a linked event; it points at the site's admin instead.
+An edit there would be discarded on the next read, which is worse than the old
+divergence — the admin would believe it had worked.
+
+Reads fail **closed to Mongo**: if the database is unreachable the bot keeps
+serving the last known values and logs. That is the opposite of remote pricing,
+which has no fallback on purpose. Showing a slightly stale address during an
+outage beats showing a registrant an error; charging a stale price does not.
 
 ## Two steps, deliberately separate
 

--- a/example.env
+++ b/example.env
@@ -47,6 +47,26 @@ EVENT_PAYMENTS_REMOTE_PRICING_ENABLED=false
 # EVENT_PAYMENTS_WEBSITE_API_BASE_URL=http://127.0.0.1:8765
 # EVENT_PAYMENTS_WEBSITE_API_TOKEN=test-dedicated-token
 
+# --- Event calendar fields read straight from the website's PostgreSQL -------
+# The website owns name/date/venue/address; the bot reads them per request and
+# keeps no copy, so the two cannot drift (28.07.2026: site said ул. Встречная,
+# bot said ул. Самаркандская). Only applies to events with a website_event_uid.
+#
+# Unlike remote pricing this DOES fall back to Mongo when the database is
+# unreachable — a stale address beats an error in a registration flow.
+#
+# Use the least-privilege role, never the owner: club146_bot_ro has SELECT on
+# events / event_registration_configs / person_telegram_links and nothing else.
+# Provision with 146.school scripts/db/provision-bot-ro.sh.
+#
+# NOTE prod: club146-pg has no public IP and only 10.128.0.0/24 + 10.129.0.0/24
+# reach :6432, so the bot must live inside the Yandex VPC. The prod bot is still
+# on Hetzner — the cutover is a hard prerequisite, not hygiene.
+WEBSITE_DB_ENABLED=false
+# WEBSITE_DATABASE_URL=postgresql://club146_bot_ro:...@rc1a-3lqp8eu74potdlj8.mdb.yandexcloud.net:6432/club146?sslmode=require
+# WEBSITE_DB_TIMEOUT_SECONDS=5
+# WEBSITE_DB_POOL_SIZE=3
+
 # dev:
 #CALMMAGE_SERVICE_REGISTRY_URL=http://localhost:8765
 # prod:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "pydantic>=2.10.6",
     "pydantic-settings>=2.7.1",
     "httpx>=0.28.1,<1",
+    # Read-only reads of the website's event data (see src/website_db.py).
+    "asyncpg>=0.30",
     "pillow>=12.1.1,<13",
     # Data visualization
     "matplotlib>=3.8.3",

--- a/scripts/coolify-deploy.sh
+++ b/scripts/coolify-deploy.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Queue a Coolify deploy for this bot. Called by `make deploy-prod` / `make deploy-dev`.
+#
+# Why this exists: prod does NOT auto-deploy. See docs/DEPLOY.md.
+#
+# Usage: scripts/coolify-deploy.sh prod|dev [--force]
+#
+# Token:  $COOLIFY_NEW_TOKEN (exported from ~/.zshrc), else
+#         CALMMAGE_COOLIFY_NEW_API_KEY from ~/.env.enc via calmlib find_env_key.
+# URL:    $COOLIFY_NEW_URL, default https://new-c.calmmage.com
+set -euo pipefail
+
+REPO="Club-146/club-146-event-registration-bot"
+PROJECT_UUID="tsctsivmf3235t2r3sp6rq03"
+ENV_UUID="v4nuwv7a15i48ixche5hbzgv"
+PROD_APP="raa8wuc20q0leqf7svr2tj83"
+DEV_APP="ch0xb09nbcgyhu9qf1hy03i5"
+
+target="${1:-}"
+case "$target" in
+  prod) app="$PROD_APP"; branch="main" ;;
+  dev)  app="$DEV_APP";  branch="dev"  ;;
+  *) echo "usage: $0 prod|dev [--force]" >&2; exit 2 ;;
+esac
+
+force="false"
+[[ "${2:-}" == "--force" || "${FORCE:-0}" == "1" || "${FORCE:-0}" == "true" ]] && force="true"
+
+url="${COOLIFY_NEW_URL:-https://new-c.calmmage.com}"
+token="${COOLIFY_NEW_TOKEN:-}"
+if [[ -z "$token" ]]; then
+  token=$(cd "$HOME/work/calmmage" && uv run python -c \
+    'from calmlib.utils import find_env_key; print(find_env_key("CALMMAGE_COOLIFY_NEW_API_KEY") or "")' \
+    2>/dev/null | tail -1)
+fi
+if [[ -z "$token" ]]; then
+  echo "no Coolify token — export COOLIFY_NEW_TOKEN, or set CALMMAGE_COOLIFY_NEW_API_KEY in ~/.env.enc" >&2
+  exit 1
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+api() {  # api <path> -> prints http code, body lands in $tmp
+  curl -sS -o "$tmp" -w "%{http_code}" \
+    -H "Authorization: Bearer $token" -H "Accept: application/json" "$url$1"
+}
+
+# Preflight. A wrong instance/token answers 404 "No resources found", which reads
+# like the app vanished — fail loudly instead, and confirm we hit the right app.
+code=$(api "/api/v1/applications/$app")
+if [[ "$code" != "200" ]]; then
+  echo "cannot read app $app on $url (HTTP $code) — wrong Coolify instance or token?" >&2
+  cat "$tmp" >&2; echo >&2
+  exit 1
+fi
+name=$(python3 - "$tmp" "$REPO" "$branch" <<'PY'
+import json, sys
+app = json.load(open(sys.argv[1]))
+_, _, want_repo, want_branch = sys.argv
+if app.get("git_repository") != want_repo:
+    sys.exit(f"refusing: app tracks {app.get('git_repository')!r}, expected {want_repo!r}")
+if app.get("git_branch") != want_branch:
+    sys.exit(f"refusing: app tracks branch {app.get('git_branch')!r}, expected {want_branch!r}")
+print(app.get("name", ""))
+PY
+)
+
+echo "Queueing Coolify deploy: $name  (branch $branch, force=$force)"
+code=$(api "/api/v1/deploy?uuid=$app&force=$force")
+cat "$tmp"; echo
+if [[ "$code" != "200" ]]; then
+  echo "deploy failed HTTP $code" >&2
+  exit 1
+fi
+
+echo "OK — watch: $url/project/$PROJECT_UUID/environment/$ENV_UUID/application/$app"
+echo "Logs should show: payment reminder scheduler started (daily 09:00 Europe/Moscow + catch-up :15 hours 9-17 MSK)"

--- a/src/amount_parse.py
+++ b/src/amount_parse.py
@@ -1,0 +1,118 @@
+"""Parse human-entered ruble amounts from admin/payment chat input."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+# Trailing currency markers: "руб", "руб.", "рублей", "р", "₽", "RUB", ...
+_CURRENCY_SUFFIX = re.compile(
+    r"(?i)\s*(?:"
+    r"руб(?:\.|лей|ля|ль)?"
+    r"|р\.?"
+    r"|₽"
+    r"|rub(?:les?)?"
+    r")\s*$"
+)
+# Spaces used as thousand separators (regular, NBSP, narrow NBSP)
+_THOUSAND_SPACES = re.compile(r"[\s\u00a0\u202f]+")
+
+
+def message_text(value: Any) -> Optional[str]:
+    """Extract text from an aiogram Message, a plain str, or None.
+
+    ``ask_user_raw`` returns a Message; tests often mock a bare string.
+    ``str(Message)`` is the full object dump and must never be parsed as input.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    text = getattr(value, "text", None)
+    if text is None:
+        return None
+    return str(text)
+
+
+def parse_rubles_amount(raw: Any) -> Optional[int]:
+    """Parse a ruble amount into a non-negative integer.
+
+    Accepted examples:
+      - ``1900``
+      - ``1900 руб`` / ``1900р`` / ``1900 ₽``
+      - ``1900,00`` / ``1900.00``
+      - ``1 900`` / ``1 900,00 руб``
+      - ``1.900,00`` (EU) / ``1,900.00`` (US)
+
+    Returns None if the value cannot be parsed or is negative.
+    Fractional rubles are rounded to the nearest integer.
+    """
+    text = message_text(raw)
+    if text is None:
+        return None
+    text = text.strip()
+    if not text:
+        return None
+
+    text = _CURRENCY_SUFFIX.sub("", text).strip()
+    text = _THOUSAND_SPACES.sub("", text)
+    if not text:
+        return None
+
+    text = _normalize_decimal_separators(text)
+    if text is None:
+        return None
+
+    try:
+        value = float(text)
+    except ValueError:
+        return None
+    if value < 0 or value != value:  # NaN
+        return None
+    return int(round(value))
+
+
+def _normalize_decimal_separators(text: str) -> Optional[str]:
+    """Turn a digit string with ,/. thousand/decimal separators into a float-ready form."""
+    if "," in text and "." in text:
+        if text.rfind(",") > text.rfind("."):
+            # European: 1.900,00
+            text = text.replace(".", "").replace(",", ".")
+        else:
+            # US: 1,900.00
+            text = text.replace(",", "")
+        return text if _is_float_literal(text) else None
+
+    if "," in text:
+        parts = text.split(",")
+        if len(parts) == 2 and parts[1].isdigit() and 1 <= len(parts[1]) <= 2:
+            text = f"{parts[0]}.{parts[1]}"
+        else:
+            text = text.replace(",", "")
+        return text if _is_float_literal(text) else None
+
+    if "." in text:
+        parts = text.split(".")
+        if not all(p.isdigit() for p in parts if p != ""):
+            # allow leading empty only for ".5" — we don't need that for rubles
+            return text if _is_float_literal(text) else None
+        if len(parts) == 2 and 1 <= len(parts[1]) <= 2:
+            # decimal: 1900.00
+            return text if _is_float_literal(text) else None
+        if len(parts) >= 2 and all(len(p) == 3 for p in parts[1:]) and parts[0].isdigit():
+            # thousand separators: 1.900 or 1.900.000
+            text = "".join(parts)
+            return text if text.isdigit() else None
+        return text if _is_float_literal(text) else None
+
+    return text if _is_float_literal(text) else None
+
+
+def _is_float_literal(text: str) -> bool:
+    if not text or text in {".", "-", "+"}:
+        return False
+    try:
+        float(text)
+        return True
+    except ValueError:
+        return False

--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,19 @@ class AppSettings(BaseSettings):
     event_payments_api_timeout_seconds: float = Field(default=5.0, gt=0, le=30)
     event_payments_sync_interval_seconds: float = Field(default=15.0, ge=5, le=300)
 
+    # Read event calendar fields (name, date, venue, address) from the website's
+    # PostgreSQL instead of the Mongo document, making the website the single
+    # owner of where and when an event happens. Applies only to events that
+    # carry a website_event_uid.
+    #
+    # Unlike remote pricing, this DOES fall back to Mongo on failure: showing a
+    # slightly stale address while the database is unreachable beats showing a
+    # registrant an error, whereas charging a stale price does not.
+    website_db_enabled: bool = False
+    website_database_url: SecretStr = SecretStr("")
+    website_db_timeout_seconds: float = Field(default=5.0, gt=0, le=30)
+    website_db_pool_size: int = Field(default=3, ge=1, le=20)
+
     delay_messages: bool = True
 
     class Config:
@@ -180,6 +193,7 @@ class App:
         self._export_debounce_task: asyncio.Task | None = None
         self._export_debounce_seconds = 30
         self._event_payment_sync_task: asyncio.Task | None = None
+        self._website_events = None
 
     async def startup(self):
         """Run startup tasks like fixing the database and initializing collections."""
@@ -226,6 +240,14 @@ class App:
                 await task
             except asyncio.CancelledError:
                 pass
+
+        reader = self._website_events
+        self._website_events = None
+        if reader is not None:
+            try:
+                await reader.close()
+            except Exception as exc:  # noqa: BLE001 — shutdown must not fail
+                logger.warning(f"website_db: pool close failed: {exc}")
 
     @property
     def collection(self):
@@ -527,6 +549,29 @@ class App:
 
     # ---- Event methods ----
 
+    @property
+    def website_events(self):
+        """Reader for the website's event rows (see src/website_db.py)."""
+        if self._website_events is None:
+            from src.website_db import WebsiteEventReader
+
+            self._website_events = WebsiteEventReader(self.settings)
+        return self._website_events
+
+    async def _resolve(self, event: Optional[Dict]) -> Optional[Dict]:
+        """Apply the website's calendar fields to one event.
+
+        Every event read goes through here, which is the point: the website owns
+        name/date/venue/address, and making that true at the single place events
+        are loaded means no caller has to remember it. Returns the Mongo
+        document unchanged when the feature is off, when the event has no
+        website_event_uid, or when the website cannot be reached.
+        """
+        return await self.website_events.resolve_event(event)
+
+    async def _resolve_many(self, events: List[Dict]) -> List[Dict]:
+        return [await self._resolve(event) for event in events]
+
     async def get_active_events(self) -> List[Dict]:
         """Get all events that are upcoming or have open registration."""
         cursor = self.events_col.find(
@@ -534,7 +579,7 @@ class App:
                 "status": {"$in": ["upcoming", "registration_closed"]},
             }
         ).sort("date", 1)
-        return await cursor.to_list(length=None)
+        return await self._resolve_many(await cursor.to_list(length=None))
 
     async def get_enabled_events(self) -> List[Dict]:
         """Get all events that are enabled for registration (upcoming + enabled)."""
@@ -544,27 +589,30 @@ class App:
                 "enabled": True,
             }
         ).sort("date", 1)
-        return await cursor.to_list(length=None)
+        return await self._resolve_many(await cursor.to_list(length=None))
 
     async def get_event_by_id(self, event_id: str) -> Optional[Dict]:
         """Get a single event by its MongoDB _id."""
         from bson import ObjectId
 
         try:
-            return await self.events_col.find_one({"_id": ObjectId(event_id)})
+            event = await self.events_col.find_one({"_id": ObjectId(event_id)})
         except Exception:
             return None
+        return await self._resolve(event)
 
     async def get_event_by_city_and_date(
         self, city: str, date: datetime
     ) -> Optional[Dict]:
         """Find an event matching city and date."""
-        return await self.events_col.find_one({"city": city, "date": date})
+        return await self._resolve(
+            await self.events_col.find_one({"city": city, "date": date})
+        )
 
     async def get_all_events(self) -> List[Dict]:
         """Get all events (for admin)."""
         cursor = self.events_col.find().sort("date", -1)
-        return await cursor.to_list(length=None)
+        return await self._resolve_many(await cursor.to_list(length=None))
 
     async def create_event(self, event_data: Dict) -> str:
         """Create a new event. Returns the inserted _id as string."""
@@ -601,7 +649,7 @@ class App:
         event = await self.events_col.find_one(
             {"$or": [{"city": target_city}, {"name": {"$regex": target_city}}]}
         )
-        return event
+        return await self._resolve(event)
 
     async def get_registration_count_for_event(self, event_id: str) -> int:
         """Count registrations for a specific event."""

--- a/src/date_display.py
+++ b/src/date_display.py
@@ -1,0 +1,52 @@
+"""Russian date rendering for event cards and menus.
+
+Lives in its own module because two very different layers need it: the admin
+event editor (routers) and the website-event overlay (``website_db``). Importing
+the routers package from the data layer would invert the dependency, and
+duplicating the month table would let the two drift — which is exactly the class
+of bug this whole change is about.
+"""
+
+from datetime import datetime
+
+MONTH_NAMES_RU = {
+    1: "Января",
+    2: "Февраля",
+    3: "Марта",
+    4: "Апреля",
+    5: "Мая",
+    6: "Июня",
+    7: "Июля",
+    8: "Августа",
+    9: "Сентября",
+    10: "Октября",
+    11: "Ноября",
+    12: "Декабря",
+}
+
+DAY_OF_WEEK_RU = {
+    0: "Пн",
+    1: "Вт",
+    2: "Ср",
+    3: "Чт",
+    4: "Пт",
+    5: "Сб",
+    6: "Вс",
+}
+
+
+def make_date_display(dt: datetime) -> str:
+    """`datetime(2026, 8, 1)` -> `"1 Августа, Сб"`."""
+    day_name = DAY_OF_WEEK_RU.get(dt.weekday(), "")
+    month_name = MONTH_NAMES_RU.get(dt.month, "")
+    return f"{dt.day} {month_name}, {day_name}"
+
+
+def make_time_display(dt: datetime) -> str:
+    """`datetime(2026, 8, 1, 18, 0)` -> `"18:00"`.
+
+    The bot's own ``time_display`` is free text (operators write things like
+    "18:00-00:00"), so this is only used when the website supplies the time and
+    therefore owns it.
+    """
+    return f"{dt.hour:02d}:{dt.minute:02d}"

--- a/src/routers/_events_helpers.py
+++ b/src/routers/_events_helpers.py
@@ -137,36 +137,14 @@ def _format_event_summary(event: dict, reg_count: int = 0) -> str:
     return "\n".join(lines)
 
 
-MONTH_NAMES_RU = {
-    1: "Января",
-    2: "Февраля",
-    3: "Марта",
-    4: "Апреля",
-    5: "Мая",
-    6: "Июня",
-    7: "Июля",
-    8: "Августа",
-    9: "Сентября",
-    10: "Октября",
-    11: "Ноября",
-    12: "Декабря",
-}
-
-DAY_OF_WEEK_RU = {
-    0: "Пн",
-    1: "Вт",
-    2: "Ср",
-    3: "Чт",
-    4: "Пт",
-    5: "Сб",
-    6: "Вс",
-}
-
-
-def _make_date_display(dt: datetime) -> str:
-    day_name = DAY_OF_WEEK_RU.get(dt.weekday(), "")
-    month_name = MONTH_NAMES_RU.get(dt.month, "")
-    return f"{dt.day} {month_name}, {day_name}"
+# Moved to src/date_display.py so the website-event overlay can render dates the
+# same way without importing the routers package. Re-exported here because this
+# is where every existing caller (and test) looks for them.
+from src.date_display import (  # noqa: E402,F401
+    DAY_OF_WEEK_RU,
+    MONTH_NAMES_RU,
+    make_date_display as _make_date_display,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -1064,6 +1042,39 @@ async def _handle_edit_message_templates(
     await send_safe(chat_id, f"✅ «{spec.title}» обновлён.")
 
 
+# Fields the website owns once an event is linked to it. Editing these in the
+# bot is precisely what caused the 28.07.2026 divergence: an admin changed the
+# venue here, nobody changed it on the site, and the two systems advertised
+# different addresses for the same party. The bot now READS these from the
+# website, so an edit here would be silently discarded on the next read — which
+# is worse than the old behaviour, because the admin would believe it worked.
+#
+# Time is deliberately NOT in this set: `time_display` is free text the operators
+# write themselves ("18:00-00:00"), and the overlay only fills it when Mongo has
+# none, so it stays genuinely bot-owned.
+WEBSITE_OWNED_EDIT_FIELDS = {
+    "name": "Название",
+    "date": "Дата",
+    "venue": "Место",
+    "address": "Адрес",
+}
+
+
+def website_owns_event_calendar(app: App, event: dict) -> bool:
+    """True when this event's calendar fields come from the website."""
+    from src.website_db import website_db_requested
+
+    uid = event.get("website_event_uid")
+    return bool(isinstance(uid, str) and uid.strip()) and website_db_requested(
+        app.settings
+    )
+
+
+def _site_events_admin_url(app: App) -> str:
+    base = (getattr(app.settings, "payment_site_base_url", "") or "").rstrip("/")
+    return f"{base}/admin/events" if base else "админку сайта"
+
+
 async def _handle_edit_event(
     chat_id: int,
     state: FSMContext,
@@ -1073,28 +1084,52 @@ async def _handle_edit_event(
     user_id: int,
     username: str | None,
 ) -> None:
+    site_owned = website_owns_event_calendar(app, event)
+
+    choices = {
+        "name": "Название",
+        "date": "Дата",
+        "time": "Время",
+        "venue": "Место",
+        "address": "Адрес",
+        "image": "Изображение",
+        "pricing": "Настройки оплаты",
+        "early_bird": "Ранняя регистрация",
+        "ask_bring_food": "Еда при поздней оплате",
+        "guests": "Настройки гостей",
+        "templates": "Тексты сообщений",
+        "back": "Назад",
+    }
+    prompt = "Что изменить?"
+    if site_owned:
+        # Hide rather than offer-and-refuse: an option that always fails is just
+        # a worse error message.
+        for key in WEBSITE_OWNED_EDIT_FIELDS:
+            choices.pop(key, None)
+        prompt = (
+            "Что изменить?\n\n"
+            "ℹ️ Название, дату и место этого события задаёт сайт — "
+            f"меняйте их в {_site_events_admin_url(app)}. "
+            "Бот читает их оттуда, поэтому правка здесь всё равно бы потерялась."
+        )
+
     field = await ask_user_choice(
         chat_id,
-        "Что изменить?",
-        choices={
-            "name": "Название",
-            "date": "Дата",
-            "time": "Время",
-            "venue": "Место",
-            "address": "Адрес",
-            "image": "Изображение",
-            "pricing": "Настройки оплаты",
-            "early_bird": "Ранняя регистрация",
-            "ask_bring_food": "Еда при поздней оплате",
-            "guests": "Настройки гостей",
-            "templates": "Тексты сообщений",
-            "back": "Назад",
-        },
+        prompt,
+        choices=choices,
         state=state,
         timeout=None,
     )
 
     if field == "back":
+        return
+    # Defensive: a stale menu callback could still carry a site-owned field.
+    elif site_owned and field in WEBSITE_OWNED_EDIT_FIELDS:
+        await send_safe(
+            chat_id,
+            f"⚠️ «{WEBSITE_OWNED_EDIT_FIELDS[field]}» задаётся на сайте: "
+            f"{_site_events_admin_url(app)}",
+        )
         return
     elif field == "name":
         await _handle_edit_field_name(

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -23,6 +23,7 @@ from src.website_event_bridge import (
 )
 from botspot import commands_menu
 from botspot.components.qol.bot_commands_menu import Visibility
+from src.amount_parse import message_text, parse_rubles_amount
 from src.user_interactions import ask_user_choice, ask_user_raw
 from botspot.utils import send_safe
 from botspot.utils.admin_filter import AdminFilter
@@ -247,10 +248,11 @@ async def _resolve_manual_user(
         state=state,
         timeout=300,
     )
-    if not username_input:
+    username_raw = message_text(username_input)
+    if not username_raw:
         await send_safe(chat_id, "Время ожидания истекло.")
         return None
-    username_clean = str(username_input).lstrip("@").strip()
+    username_clean = username_raw.lstrip("@").strip()
     reg = await app.collection.find_one(
         {"username": username_clean, "event_id": event_id}
     )
@@ -273,15 +275,16 @@ async def _confirm_payment_amount(
         state=state,
         timeout=300,
     )
-    if not amount_input:
+    amount_raw = message_text(amount_input)
+    if amount_raw is None:
         await send_safe(chat_id, "Время ожидания истекло.")
         return None
 
-    try:
-        return int(str(amount_input).strip())
-    except ValueError:
+    amount = parse_rubles_amount(amount_raw)
+    if amount is None:
         await send_safe(chat_id, "Неверный формат суммы.")
         return None
+    return amount
 
 
 async def _send_admin_confirmed_ticket(

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -19,6 +19,7 @@ from src.app import App, GraduateType
 from src.router import is_admin, commands_menu, get_event_date_display
 from src.routers.admin import PaymentInfo
 from src.ticket_cards import send_paid_ticket_card
+from src.amount_parse import message_text, parse_rubles_amount
 from src.user_interactions import ask_user_raw, ask_user_choice, ask_user_choice_raw
 from src.website_event_bridge import (
     WebsiteBridgeError,
@@ -1472,24 +1473,25 @@ async def _resolve_payment_amount(
             state=state,
             timeout=300,
         )
-        if amount_response is None or amount_response.text is None:
+        amount_raw = message_text(amount_response)
+        if amount_raw is None:
             await send_safe(chat_id, "Время ожидания истекло. Операция отменена.")
             logger.warning(f"Payment amount input timeout for user in city {city}")
             return None
-        try:
-            return int(amount_response.text)
-        except ValueError:
+        amount = parse_rubles_amount(amount_raw)
+        if amount is None:
             await send_safe(
                 chat_id,
                 "Некорректная сумма платежа. Пожалуйста, используйте команду снова.",
             )
             return None
+        return amount
     else:
-        try:
-            return int(amount_str)
-        except ValueError:
+        amount = parse_rubles_amount(amount_str)
+        if amount is None:
             await callback_query.answer("Invalid amount in callback data")
             return None
+        return amount
 
 
 def _build_payment_status_text(

--- a/src/website_db.py
+++ b/src/website_db.py
@@ -1,0 +1,191 @@
+"""Read event data straight from the website's PostgreSQL.
+
+Why this exists
+---------------
+The site and the bot each kept their own copy of an event. Nothing synced them
+and the bot's admin let you edit the place, so on 28.07.2026 the site advertised
+ул. Встречная while the bot told registrants ул. Самаркандская. Two stores, two
+write paths, no reconciliation — divergence was the default outcome, not an
+accident.
+
+The fix is not a sync job. A sync job copies, and anything copied can be stale;
+it also needs a conflict rule the moment both sides can write. Instead the bot
+*reads through* to the site and never persists what it reads, so there is no
+second copy that can drift. Mongo keeps only what the bot genuinely owns:
+pricing, registration open/closed, templates, and the registrations themselves.
+
+Access is a dedicated least-privilege role (``club146_bot_ro``) with SELECT on
+three tables and nothing else — see 146.school ``scripts/db/``. In particular it
+cannot read ``people`` or ``donations``.
+
+Failure policy
+--------------
+Fails **closed to Mongo**: any error — unreachable database, missing row,
+malformed value — leaves the Mongo document untouched and logs. That is the
+opposite of ``resolve_event_pricing``, which deliberately has no fallback, and
+the difference is intentional: charging a stale *price* is a real harm, whereas
+showing a slightly stale *address* while the database is down is strictly better
+than showing the user an error. Availability wins here; correctness wins there.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from typing import Any, Mapping, Optional
+
+from loguru import logger
+
+from src.date_display import make_date_display, make_time_display
+
+# Columns the bot reads. Explicit rather than SELECT *: the grant is narrow on
+# purpose, and naming the columns means a schema change surfaces here as a clear
+# error instead of quietly widening what the bot pulls.
+_EVENT_QUERY = """
+    SELECT uid, title, starts_at, venue, address, url, published
+      FROM events
+     WHERE uid = $1
+       AND published = true
+     LIMIT 1
+"""
+
+# Events change rarely; bot menus hit these getters on nearly every keystroke.
+# Without a cache a single user browsing the menu would open a Postgres round
+# trip per tap.
+_CACHE_TTL_SECONDS = 60.0
+
+
+def website_db_requested(settings: Any) -> bool:
+    """True only for an explicit literal enable flag."""
+    return getattr(settings, "website_db_enabled", False) is True
+
+
+def _clean(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def merge_website_event(event: Mapping[str, Any], row: Mapping[str, Any]) -> dict:
+    """Overlay the website's calendar fields onto a copy of the Mongo event.
+
+    The overlaid keys keep the Mongo document's own names, so every existing
+    consumer — the event menu, /status, the CRM mailer, ticket cards — keeps
+    reading the same keys off the same dict and cannot end up reading two
+    different sources. Authority moves, call sites do not. (Same shape as
+    ``merge_remote_pricing`` in ``website_event_bridge``.)
+
+    Returns a **copy**. Nothing here is ever written back to Mongo — that is
+    what makes a second source of truth impossible rather than merely
+    discouraged.
+    """
+    resolved = dict(event)
+
+    title = _clean(row.get("title"))
+    if title:
+        resolved["name"] = title
+
+    # venue is optional on the website by decision; address carries the rest.
+    # Assign both together — taking one from the site and leaving the other from
+    # Mongo would render a place that exists in neither system.
+    venue = _clean(row.get("venue"))
+    address = _clean(row.get("address"))
+    if venue or address:
+        resolved["venue"] = venue or None
+        resolved["address"] = address or None
+
+    starts_at = row.get("starts_at")
+    if isinstance(starts_at, datetime):
+        # Both sides store naive Perm local time (UTC+5, no DST), so this is a
+        # straight assignment. date_display is derived rather than copied: it is
+        # the string users actually read, and leaving it stale while `date`
+        # moved would recreate the very divergence this module removes.
+        resolved["date"] = starts_at
+        resolved["date_display"] = make_date_display(starts_at)
+        if not _clean(event.get("time_display")):
+            resolved["time_display"] = make_time_display(starts_at)
+
+    url = _clean(row.get("url"))
+    if url:
+        resolved["website_url"] = url
+
+    return resolved
+
+
+class WebsiteEventReader:
+    """Lazily-connected, cached, fail-closed reader for the website's events."""
+
+    def __init__(self, settings: Any):
+        self.settings = settings
+        self._pool = None
+        self._cache: dict[str, tuple[float, Optional[dict]]] = {}
+
+    def enabled(self) -> bool:
+        return website_db_requested(self.settings) and bool(
+            self._dsn()
+        )
+
+    def _dsn(self) -> str:
+        raw = getattr(self.settings, "website_database_url", None)
+        if raw is None:
+            return ""
+        # SecretStr or plain str, depending on how it was configured.
+        return _clean(raw.get_secret_value() if hasattr(raw, "get_secret_value") else raw)
+
+    async def _get_pool(self):
+        if self._pool is None:
+            import asyncpg  # imported lazily so the bot runs without the driver
+
+            timeout = float(
+                getattr(self.settings, "website_db_timeout_seconds", 5.0)
+            )
+            self._pool = await asyncpg.create_pool(
+                self._dsn(),
+                min_size=1,
+                max_size=int(getattr(self.settings, "website_db_pool_size", 3)),
+                command_timeout=timeout,
+                timeout=timeout,
+            )
+        return self._pool
+
+    async def get_event_by_uid(self, uid: str) -> Optional[dict]:
+        """Return the website's row for `uid`, or None. Never raises."""
+        uid = _clean(uid)
+        if not uid or not self.enabled():
+            return None
+
+        cached = self._cache.get(uid)
+        if cached is not None and (time.monotonic() - cached[0]) < _CACHE_TTL_SECONDS:
+            return cached[1]
+
+        try:
+            pool = await self._get_pool()
+            record = await pool.fetchrow(_EVENT_QUERY, uid)
+        except Exception as exc:  # noqa: BLE001 — fail closed, never surface
+            # Deliberately not re-raised: the caller falls back to Mongo, and a
+            # stale address beats an error message in a registration flow.
+            logger.warning(f"website_db: read failed for {uid!r}, using Mongo: {exc}")
+            # Keep serving the last good value if we have one, rather than
+            # flapping between website and Mongo on an intermittent database.
+            return cached[1] if cached is not None else None
+
+        row = dict(record) if record is not None else None
+        self._cache[uid] = (time.monotonic(), row)
+        return row
+
+    async def resolve_event(self, event: Optional[dict]) -> Optional[dict]:
+        """Return `event` with website calendar fields applied, or unchanged."""
+        if not event or not self.enabled():
+            return event
+        uid = _clean(event.get("website_event_uid"))
+        if not uid:
+            # Not linked to a website event — Mongo is its only possible source
+            # and that is not a divergence.
+            return event
+        row = await self.get_event_by_uid(uid)
+        if row is None:
+            return event
+        return merge_website_event(event, row)
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None

--- a/tests/test_amount_parse.py
+++ b/tests/test_amount_parse.py
@@ -1,0 +1,75 @@
+"""Tests for human-entered ruble amount parsing."""
+
+from datetime import datetime
+
+import pytest
+from aiogram.types import Chat, Message
+
+from src.amount_parse import message_text, parse_rubles_amount
+
+
+def _msg(text: str) -> Message:
+    return Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=Chat(id=1, type="private"),
+        text=text,
+    )
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("1900", 1900),
+        ("1900 руб", 1900),
+        ("1900 руб.", 1900),
+        ("1900р", 1900),
+        ("1900 ₽", 1900),
+        ("1900,00", 1900),
+        ("1900.00", 1900),
+        ("1 900", 1900),
+        ("1 900,00", 1900),
+        ("1 900 руб", 1900),
+        ("1.900,00", 1900),
+        ("1,900.00", 1900),
+        ("  2500  ", 2500),
+        ("2500.6", 2501),  # rounds half-up-ish via float+round
+        ("0", 0),
+        ("0,00 руб", 0),
+    ],
+)
+def test_parse_rubles_amount_accepted(raw, expected):
+    assert parse_rubles_amount(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "руб",
+        "abc",
+        "-100",
+        "сто",
+        None,
+    ],
+)
+def test_parse_rubles_amount_rejected(raw):
+    assert parse_rubles_amount(raw) is None
+
+
+def test_parse_rubles_amount_from_message():
+    """Regression: str(Message) is a dump — must use .text."""
+    msg = _msg("1900")
+    assert parse_rubles_amount(msg) == 1900
+    assert parse_rubles_amount(_msg("1900 руб")) == 1900
+    assert parse_rubles_amount(_msg("1900,00")) == 1900
+    # str(Message) itself must not parse as a valid amount
+    assert parse_rubles_amount(str(msg)) is None
+
+
+def test_message_text_handles_message_and_str():
+    assert message_text(_msg("hello")) == "hello"
+    assert message_text("plain") == "plain"
+    assert message_text(None) is None
+    assert message_text(_msg("")) == ""

--- a/tests/test_guest_pricing_parity.py
+++ b/tests/test_guest_pricing_parity.py
@@ -1,0 +1,133 @@
+"""One guest-pricing rule, asserted identically in both repos.
+
+Decided by Petr, 27 Jul 2026: **a guest who gives a school year is priced
+exactly like a registrant of that year; a guest with no school year pays the
+flat guest rate.**
+
+Before this, the website charged every guest a flat `guest_price_fixed` while
+the bot priced guests by their own graduation year. The same person cost 1500
+as a website guest and 7600 as a bot guest, so registering a classmate as your
+"guest" was a 6100₽ discount on registering as yourself.
+
+THE TABLE BELOW IS SHARED. Its twin lives at
+`146.school/newsite/tests/test_guest_pricing_parity.py`. This side is the
+canonical implementation -- `App.calculate_guest_price` -- and the website was
+changed to match it. If you change guest pricing in either repo, both copies
+must be updated together or one of the two suites fails; that is the entire
+point of duplicating the table rather than importing it. A shared fixture would
+be nicer but the two services have separate venvs and no shared package.
+
+The rule needs **no code change on this side**. It only requires
+`guest_price_minimum` to be set to the intended flat guest rate (1500), because
+that single field serves as both the floor for alum guests and the price for a
+«друг». With it at 0, a «друг» falls through to "the formula for someone who
+left 15 years ago" (4400 for the Aug 1 config), which is not the intent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.app import App
+
+# (graduation_year | None, early_bird_active) -> expected amount in rubles.
+#
+# Config: base 1400, rate 200, reference year 2026, step 1,
+#         guest_price_minimum = 1500, early_bird_discount 500,
+#         free_for_types ["TEACHER"].
+CANONICAL_GUEST_PRICES = {
+    # a guest who is an alum pays what that alum would pay
+    (2026, False): 1500,  # 1400 formula, floored up to the 1500 minimum
+    (2024, False): 1800,
+    (2010, False): 4600,
+    (1995, False): 7600,
+    # ...and the early-bird discount comes off after the floor
+    (2026, True): 1000,  # floored to 1500, then -500
+    (2024, True): 1300,
+    (2010, True): 4100,
+    (1995, True): 7100,
+    # no school year -> the flat guest rate, discount still applies
+    (None, False): 1500,
+    (None, True): 1000,
+}
+
+
+class _Shim:
+    """`calculate_guest_price` only needs its sibling method, not a live bot."""
+
+    calculate_event_payment = App.calculate_event_payment
+    calculate_guest_price = App.calculate_guest_price
+
+
+def _event(*, early_bird: bool) -> dict:
+    from datetime import datetime, timedelta
+
+    event = {
+        "_id": "6a599a17a37724d81b7eadc3",
+        "pricing_type": "formula",
+        "price_formula_base": 1400,
+        "price_formula_rate": 200,
+        "price_formula_reference_year": 2026,
+        "price_formula_step": 1,
+        # the flat guest rate AND the floor for alum guests -- one field
+        "guest_price_minimum": 1500,
+        "free_for_types": ["TEACHER"],
+        "early_bird_discount": 500 if early_bird else 0,
+    }
+    if early_bird:
+        # is_early_bird_active falls back to D-3 of the event date
+        event["date"] = datetime.now() + timedelta(days=10)
+    return event
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    sorted(
+        CANONICAL_GUEST_PRICES.items(), key=lambda item: (item[0][0] or 0, item[0][1])
+    ),
+)
+def test_matches_the_canonical_table(key, expected):
+    year, early_bird = key
+    app = _Shim()
+    # A guest with no school year is the NON_GRADUATE branch.
+    graduate_type = "GRADUATE" if year is not None else "NON_GRADUATE"
+    regular, discounted = app.calculate_guest_price(
+        _event(early_bird=early_bird),
+        year if year is not None else 2011,
+        graduate_type,
+    )
+    assert (discounted if early_bird else regular) == expected
+
+
+def test_an_alum_guest_is_not_cheaper_than_registering_as_themselves():
+    """The loophole this rule closes."""
+    app = _Shim()
+    event = _event(early_bird=False)
+    as_guest, _ = app.calculate_guest_price(event, 1995, "GRADUATE")
+    as_registrant, _, _, _ = app.calculate_event_payment(event, 1995, "GRADUATE")
+    assert as_guest == as_registrant == 7600
+
+
+def test_a_free_type_guest_pays_nothing_and_is_not_floored_up():
+    """Free types short-circuit to 0 *before* the minimum applies -- otherwise a
+    teacher brought as a guest would be charged the 1500 floor."""
+    app = _Shim()
+    assert app.calculate_guest_price(_event(early_bird=False), 2010, "TEACHER") == (
+        0,
+        0,
+    )
+
+
+def test_a_zero_minimum_does_not_give_the_intended_flat_rate():
+    """Documents why the config must set guest_price_minimum=1500.
+
+    With it at 0 a «друг» falls through to the 15-years-ago formula, which is
+    4400 -- not the 1500 the flat rate is meant to be. This is a config
+    requirement, not a code path, so it is pinned here.
+    """
+    app = _Shim()
+    event = _event(early_bird=False)
+    event["guest_price_minimum"] = 0
+    regular, _ = app.calculate_guest_price(event, 2011, "NON_GRADUATE")
+    assert regular == 4400
+    assert regular != CANONICAL_GUEST_PRICES[(None, False)]

--- a/tests/test_website_db_events.py
+++ b/tests/test_website_db_events.py
@@ -1,0 +1,318 @@
+"""The website as the single source of truth for where and when an event is.
+
+The defect this closes: the site and the bot each stored the event's place, the
+bot's admin could edit its copy, and nothing reconciled them. On 28.07.2026 the
+site advertised ул. Встречная while the bot told 46 registrants ул. Самаркандская.
+Neither was "wrong" — there were simply two truths and no rule saying which won.
+
+The fix is read-through, not sync. A sync job copies, and a copy can be stale;
+it also needs a conflict rule the moment both sides can write. Here the bot holds
+no copy at all: it reads the website's row and overlays it onto an in-memory copy
+of the Mongo document, so there is nothing to drift.
+
+Two properties matter and are pinned below:
+
+1. Nothing is ever written back to Mongo. If it were, we would be back to two
+   stores that can disagree.
+2. The bot's own admin can no longer edit these fields. Without that, an edit
+   would be silently discarded on the next read — worse than the old bug,
+   because the admin would believe it had worked.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import SecretStr
+
+from src.website_db import (
+    WebsiteEventReader,
+    merge_website_event,
+    website_db_requested,
+)
+
+WEBSITE_UID = "event-1@146.school"
+
+
+def _settings(*, enabled: bool = True, url: str = "postgresql://ro@db/club146"):
+    return SimpleNamespace(
+        website_db_enabled=enabled,
+        website_database_url=SecretStr(url),
+        website_db_timeout_seconds=5.0,
+        website_db_pool_size=3,
+    )
+
+
+def _mongo_event(**overrides):
+    event = {
+        "_id": "6a599a17a37724d81b7eadc3",
+        "name": "Летняя встреча выпускников",
+        "city": "Пермь",
+        "date": datetime(2026, 8, 1, 18, 0),
+        "date_display": "1 Августа, Сб",
+        "time_display": "18:00-00:00",
+        "venue": "Старое место",
+        "address": "ул. Встречная 28",
+        "website_event_uid": WEBSITE_UID,
+        "status": "upcoming",
+        "enabled": True,
+    }
+    event.update(overrides)
+    return event
+
+
+def _website_row(**overrides):
+    row = {
+        "uid": WEBSITE_UID,
+        "title": "Летняя встреча 146 в Перми",
+        "starts_at": datetime(2026, 8, 1, 18, 0),
+        "venue": "Беседка «Банкетная»",
+        "address": "г.Пермь, ул. Самаркандская 2",
+        "url": "https://146.school/events",
+        "published": True,
+    }
+    row.update(overrides)
+    return row
+
+
+# --------------------------------------------------------------------------
+# merge_website_event
+# --------------------------------------------------------------------------
+
+
+class TestMergeWebsiteEvent:
+    def test_the_reported_divergence_is_resolved_towards_the_website(self):
+        merged = merge_website_event(_mongo_event(), _website_row())
+        assert merged["venue"] == "Беседка «Банкетная»"
+        assert merged["address"] == "г.Пермь, ул. Самаркандская 2"
+
+    def test_mongo_document_is_not_mutated(self):
+        """The whole point: the bot keeps no second copy that could drift."""
+        event = _mongo_event()
+        merge_website_event(event, _website_row())
+        assert event["venue"] == "Старое место"
+        assert event["address"] == "ул. Встречная 28"
+
+    def test_name_comes_from_the_website_title(self):
+        merged = merge_website_event(_mongo_event(), _website_row())
+        assert merged["name"] == "Летняя встреча 146 в Перми"
+
+    def test_date_display_is_derived_not_copied(self):
+        """A moved date with a stale display string is the same bug again."""
+        merged = merge_website_event(
+            _mongo_event(), _website_row(starts_at=datetime(2026, 9, 5, 19, 30))
+        )
+        assert merged["date"] == datetime(2026, 9, 5, 19, 30)
+        assert merged["date_display"] == "5 Сентября, Сб"
+
+    def test_operator_written_time_display_is_left_alone(self):
+        """`time_display` is free text the operators own ("18:00-00:00")."""
+        merged = merge_website_event(_mongo_event(), _website_row())
+        assert merged["time_display"] == "18:00-00:00"
+
+    def test_time_display_is_filled_when_mongo_has_none(self):
+        merged = merge_website_event(
+            _mongo_event(time_display=""), _website_row()
+        )
+        assert merged["time_display"] == "18:00"
+
+    def test_optional_venue_becomes_none_rather_than_empty_string(self):
+        """venue is optional on the website by decision."""
+        merged = merge_website_event(_mongo_event(), _website_row(venue=""))
+        assert merged["venue"] is None
+        assert merged["address"] == "г.Пермь, ул. Самаркандская 2"
+
+    def test_venue_and_address_move_together(self):
+        """Taking one from the site and one from Mongo renders a place that
+        exists in neither system."""
+        merged = merge_website_event(
+            _mongo_event(), _website_row(venue="", address="")
+        )
+        assert merged["venue"] == "Старое место"
+        assert merged["address"] == "ул. Встречная 28"
+
+    def test_blank_title_does_not_erase_the_name(self):
+        merged = merge_website_event(_mongo_event(), _website_row(title=""))
+        assert merged["name"] == "Летняя встреча выпускников"
+
+    def test_unrelated_bot_owned_fields_survive(self):
+        merged = merge_website_event(_mongo_event(), _website_row())
+        assert merged["enabled"] is True
+        assert merged["status"] == "upcoming"
+        assert merged["_id"] == "6a599a17a37724d81b7eadc3"
+
+
+# --------------------------------------------------------------------------
+# WebsiteEventReader.resolve_event
+# --------------------------------------------------------------------------
+
+
+class TestResolveEvent:
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_the_mongo_event_untouched(self):
+        reader = WebsiteEventReader(_settings(enabled=False))
+        event = _mongo_event()
+        assert await reader.resolve_event(event) is event
+
+    @pytest.mark.asyncio
+    async def test_missing_dsn_disables_it(self):
+        reader = WebsiteEventReader(_settings(url=""))
+        assert reader.enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_unlinked_event_is_returned_untouched(self):
+        """No website_event_uid means Mongo is its only possible source, which
+        is not a divergence."""
+        reader = WebsiteEventReader(_settings())
+        reader.get_event_by_uid = AsyncMock()
+        event = _mongo_event(website_event_uid=None)
+        assert await reader.resolve_event(event) is event
+        reader.get_event_by_uid.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_linked_event_is_overlaid(self):
+        reader = WebsiteEventReader(_settings())
+        reader.get_event_by_uid = AsyncMock(return_value=_website_row())
+        merged = await reader.resolve_event(_mongo_event())
+        assert merged["address"] == "г.Пермь, ул. Самаркандская 2"
+
+    @pytest.mark.asyncio
+    async def test_missing_website_row_falls_back_to_mongo(self):
+        reader = WebsiteEventReader(_settings())
+        reader.get_event_by_uid = AsyncMock(return_value=None)
+        event = _mongo_event()
+        assert await reader.resolve_event(event) is event
+
+    @pytest.mark.asyncio
+    async def test_database_failure_falls_back_to_mongo_and_does_not_raise(self):
+        """Fails CLOSED to Mongo, unlike pricing which has no fallback.
+
+        A stale address during a database outage beats showing a registrant an
+        error; a stale price would be an actual wrong charge.
+        """
+        reader = WebsiteEventReader(_settings())
+
+        async def _boom(*_args, **_kwargs):
+            raise OSError("connection refused")
+
+        reader._get_pool = _boom
+        event = _mongo_event()
+        assert await reader.resolve_event(event) is event
+
+    @pytest.mark.asyncio
+    async def test_none_event_stays_none(self):
+        reader = WebsiteEventReader(_settings())
+        assert await reader.resolve_event(None) is None
+
+
+class TestRequestedFlag:
+    def test_only_a_literal_true_enables_it(self):
+        assert website_db_requested(SimpleNamespace(website_db_enabled=True)) is True
+        assert website_db_requested(SimpleNamespace(website_db_enabled=1)) is False
+        assert website_db_requested(SimpleNamespace(website_db_enabled="true")) is False
+        assert website_db_requested(SimpleNamespace()) is False
+
+
+# --------------------------------------------------------------------------
+# The bot's second write path is closed
+# --------------------------------------------------------------------------
+
+
+class TestAdminCannotEditWebsiteOwnedFields:
+    def _app(self, *, enabled=True):
+        return SimpleNamespace(
+            settings=SimpleNamespace(
+                website_db_enabled=enabled,
+                payment_site_base_url="https://146.school",
+            ),
+            update_event=AsyncMock(),
+        )
+
+    def test_linked_event_is_website_owned(self):
+        from src.routers._events_helpers import website_owns_event_calendar
+
+        assert website_owns_event_calendar(self._app(), _mongo_event()) is True
+
+    def test_unlinked_event_stays_bot_owned(self):
+        from src.routers._events_helpers import website_owns_event_calendar
+
+        event = _mongo_event(website_event_uid=None)
+        assert website_owns_event_calendar(self._app(), event) is False
+
+    def test_feature_off_keeps_the_bot_in_charge(self):
+        """Rolling the flag back must restore the old editing behaviour."""
+        from src.routers._events_helpers import website_owns_event_calendar
+
+        app = self._app(enabled=False)
+        assert website_owns_event_calendar(app, _mongo_event()) is False
+
+    @pytest.mark.asyncio
+    async def test_site_owned_fields_are_removed_from_the_edit_menu(self):
+        from unittest.mock import patch
+
+        from src.routers import _events_helpers as helpers
+
+        seen = {}
+
+        async def _capture_choice(_chat_id, prompt, choices, **_kwargs):
+            seen["prompt"] = prompt
+            seen["choices"] = choices
+            return "back"
+
+        with patch.object(helpers, "ask_user_choice", _capture_choice):
+            await helpers._handle_edit_event(
+                1, None, self._app(), _mongo_event(), "e1", 2, "admin"
+            )
+
+        for blocked in ("name", "date", "venue", "address"):
+            assert blocked not in seen["choices"]
+        # Bot-owned settings must still be editable.
+        for kept in ("time", "pricing", "guests", "templates"):
+            assert kept in seen["choices"]
+        assert "сайт" in seen["prompt"].lower()
+
+    @pytest.mark.asyncio
+    async def test_stale_callback_for_a_site_owned_field_writes_nothing(self):
+        """The guard that actually protects Mongo, independent of the menu."""
+        from unittest.mock import patch
+
+        from src.routers import _events_helpers as helpers
+
+        app = self._app()
+
+        async def _pick_venue(*_args, **_kwargs):
+            return "venue"
+
+        with patch.object(helpers, "ask_user_choice", _pick_venue), \
+                patch.object(helpers, "send_safe", AsyncMock()) as send:
+            await helpers._handle_edit_event(
+                1, None, app, _mongo_event(), "e1", 2, "admin"
+            )
+
+        app.update_event.assert_not_awaited()
+        assert "сайт" in send.await_args.args[1].lower()
+
+    @pytest.mark.asyncio
+    async def test_unlinked_event_can_still_be_edited_in_the_bot(self):
+        """Events with no website counterpart keep the old admin flow."""
+        from unittest.mock import patch
+
+        from src.routers import _events_helpers as helpers
+
+        seen = {}
+
+        async def _capture_choice(_chat_id, prompt, choices, **_kwargs):
+            seen["choices"] = choices
+            return "back"
+
+        with patch.object(helpers, "ask_user_choice", _capture_choice):
+            await helpers._handle_edit_event(
+                1, None, self._app(), _mongo_event(website_event_uid=None),
+                "e1", 2, "admin",
+            )
+
+        for key in ("name", "date", "venue", "address"):
+            assert key in seen["choices"]

--- a/uv.lock
+++ b/uv.lock
@@ -296,6 +296,46 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3807,6 +3847,7 @@ version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
+    { name = "asyncpg" },
     { name = "botspot" },
     { name = "calmlib" },
     { name = "gspread" },
@@ -3859,6 +3900,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "apscheduler" },
+    { name = "asyncpg", specifier = ">=0.30" },
     { name = "botspot", git = "https://github.com/calmmage/botspot.git?rev=main" },
     { name = "calmlib", git = "https://github.com/calmmage/calmlib.git?rev=main" },
     { name = "gspread", specifier = ">=6.1.4" },


### PR DESCRIPTION
## Summary
- Bot can optionally read event name/date/venue/address from website Postgres (`WEBSITE_DB_ENABLED`, default **off** — prod stays Mongo-only until Yandex cutover).
- Fail closed to Mongo when PG unavailable.
- Admin custom payment amount parse fix.
- Explicit deploy docs; asyncpg locked.

## Deploy notes
- Prod Coolify does **not** auto-deploy; `make deploy-prod` required after merge.
- Do **not** set `WEBSITE_DB_ENABLED` on Hetzner prod (no VPC access to club146-pg).

## Commits
```
96771d8 chore: lock asyncpg for website calendar read-through
18a9d4c Track AGENTS.md as single agent source; drop WARP/GEMINI
208a52f fix(admin): parse custom payment amounts from Message text
f4f274f fix(deploy): make shipping to prod an explicit step, because merging isn't one
b861008 merge: bot reads event calendar fields from the website's Postgres
897e8b6 feat(events): read name/date/venue/address from the website's Postgres
0e60e9c test(pricing): pin the one guest-pricing rule, shared with the website
```