### PR TITLE
Stabilize payment bridge release tests across cutoff dates

### DIFF
--- a/src/amount_parse.py
+++ b/src/amount_parse.py
@@ -99,7 +99,11 @@ def _normalize_decimal_separators(text: str) -> Optional[str]:
         if len(parts) == 2 and 1 <= len(parts[1]) <= 2:
             # decimal: 1900.00
             return text if _is_float_literal(text) else None
-        if len(parts) >= 2 and all(len(p) == 3 for p in parts[1:]) and parts[0].isdigit():
+        if (
+            len(parts) >= 2
+            and all(len(p) == 3 for p in parts[1:])
+            and parts[0].isdigit()
+        ):
             # thousand separators: 1.900 or 1.900.000
             text = "".join(parts)
             return text if text.isdigit() else None

--- a/src/website_db.py
+++ b/src/website_db.py
@@ -119,24 +119,22 @@ class WebsiteEventReader:
         self._cache: dict[str, tuple[float, Optional[dict]]] = {}
 
     def enabled(self) -> bool:
-        return website_db_requested(self.settings) and bool(
-            self._dsn()
-        )
+        return website_db_requested(self.settings) and bool(self._dsn())
 
     def _dsn(self) -> str:
         raw = getattr(self.settings, "website_database_url", None)
         if raw is None:
             return ""
         # SecretStr or plain str, depending on how it was configured.
-        return _clean(raw.get_secret_value() if hasattr(raw, "get_secret_value") else raw)
+        return _clean(
+            raw.get_secret_value() if hasattr(raw, "get_secret_value") else raw
+        )
 
     async def _get_pool(self):
         if self._pool is None:
             import asyncpg  # imported lazily so the bot runs without the driver
 
-            timeout = float(
-                getattr(self.settings, "website_db_timeout_seconds", 5.0)
-            )
+            timeout = float(getattr(self.settings, "website_db_timeout_seconds", 5.0))
             self._pool = await asyncpg.create_pool(
                 self._dsn(),
                 min_size=1,

--- a/tests/test_website_event_bridge.py
+++ b/tests/test_website_event_bridge.py
@@ -131,7 +131,11 @@ class FakeClient:
 
 def test_payload_freezes_formula_total_guests_and_legal_kind():
     payload, total = build_new_intent_payload(
-        _settings(), _registration(), _event(), calculation_date=date(2026, 7, 20)
+        _settings(),
+        _registration(),
+        _event(),
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
 
     # 1400 + 200 * floor((2026 - 2016) / 3) - 500 = 1500,
@@ -167,7 +171,11 @@ async def test_replay_uses_persisted_snapshot_not_mutated_event():
     client = FakeClient()
 
     await freeze_new_registration_snapshot(
-        app, registration, event, calculation_date=date(2026, 7, 20)
+        app,
+        registration,
+        event,
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
     frozen = registration["website_event_bridge"]["intent_payload"]
     event["price_formula_base"] = 999_999
@@ -190,7 +198,11 @@ async def test_confirm_reuses_first_durable_evidence_and_stores_codes():
     event = _event()
     client = FakeClient()
     await freeze_new_registration_snapshot(
-        app, registration, event, calculation_date=date(2026, 7, 20)
+        app,
+        registration,
+        event,
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
 
     await confirm_registration_payment(
@@ -351,7 +363,11 @@ async def test_replay_sync_promotes_only_authoritative_paid_status():
     event = _event()
     client = FakeClient()
     await freeze_new_registration_snapshot(
-        app, registration, event, calculation_date=date(2026, 7, 20)
+        app,
+        registration,
+        event,
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
     app.collection.update_one.reset_mock()
 
@@ -451,6 +467,7 @@ async def test_payment_receipt_flow_keeps_full_group_totals():
             return_value=(registration, event),
         ),
         patch("src.routers.payment.bridge_enabled_for", return_value=False),
+        patch("src.payment_timeline.is_early_bird_active", return_value=True),
         patch(
             "src.routers.payment._send_payment_info_messages",
             new_callable=AsyncMock,
@@ -492,7 +509,11 @@ async def test_background_sync_pushes_provider_confirmation_exactly_once():
     app.collection.find = MagicMock(return_value=Cursor())
     client = FakeClient()
     await freeze_new_registration_snapshot(
-        app, registration, event, calculation_date=date(2026, 7, 20)
+        app,
+        registration,
+        event,
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
     client.create_response = _remote_response(status="paid", tickets=True)
 

--- a/tests/test_website_event_bridge_e2e.py
+++ b/tests/test_website_event_bridge_e2e.py
@@ -135,7 +135,11 @@ async def test_e2e_create_replay_confirm_revoke_over_http(mock_http):
     client = WebsiteEventBridgeClient(app.settings)
 
     await freeze_new_registration_snapshot(
-        app, registration, event, calculation_date=date(2026, 7, 20)
+        app,
+        registration,
+        event,
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
     # 1400 + 200*floor(10/3) - 500 = 1500 registrant + 1500 guest
     assert registration["website_event_bridge"]["expected_amount_rubles"] == 3000
@@ -185,7 +189,11 @@ async def test_e2e_provider_paid_sync_promotes_local_status(mock_http):
     client = WebsiteEventBridgeClient(app.settings)
 
     await freeze_new_registration_snapshot(
-        app, registration, event, calculation_date=date(2026, 7, 20)
+        app,
+        registration,
+        event,
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
     await create_or_replay_intent(app, registration, event, client=client)
     service.mark_provider_paid(REGISTRATION_ID)
@@ -219,7 +227,11 @@ async def test_e2e_background_sync_notifies_once(mock_http):
     app.collection.find = lambda *a, **k: Cursor()
 
     await freeze_new_registration_snapshot(
-        app, registration, event, calculation_date=date(2026, 7, 20)
+        app,
+        registration,
+        event,
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
     await create_or_replay_intent(app, registration, event, client=client)
     service.mark_provider_paid(REGISTRATION_ID)
@@ -259,7 +271,11 @@ async def test_e2e_zero_price_guest_rejected_by_mock(mock_http):
 
     with pytest.raises(Exception) as exc:
         await freeze_new_registration_snapshot(
-            app, registration, event, calculation_date=date(2026, 7, 20)
+            app,
+            registration,
+            event,
+            calculation_date=date(2026, 7, 20),
+            now=datetime(2026, 7, 20, 12),
         )
     assert "invalid_guest_price" in str(exc.value)
 
@@ -276,7 +292,11 @@ async def test_e2e_manual_admin_registration_shape_freezes(mock_http):
     client = WebsiteEventBridgeClient(app.settings)
 
     await freeze_new_registration_snapshot(
-        app, registration, event, calculation_date=date(2026, 7, 20)
+        app,
+        registration,
+        event,
+        calculation_date=date(2026, 7, 20),
+        now=datetime(2026, 7, 20, 12),
     )
     response = await create_or_replay_intent(app, registration, event, client=client)
     assert response["status"] == "pending"

--- a/tests/test_website_remote_pricing.py
+++ b/tests/test_website_remote_pricing.py
@@ -205,6 +205,7 @@ class TestMerge:
             _registration(),
             resolved,
             calculation_date=date(2026, 7, 20),
+            now=datetime(2026, 7, 20, 12),
         )
         # 1600 + 200*(2026-2010) - 500 early bird
         assert expected == 1600 + 3200 - 500
@@ -266,6 +267,7 @@ class TestQuotedPriceGuard:
             registration,
             event,
             calculation_date=date(2026, 7, 20),
+            now=datetime(2026, 7, 20, 12),
             client=client,
         )
 


### PR DESCRIPTION
## What changed

- pins payment bridge tests to the scenario's explicit pre-cutoff instant
- removes calendar-time dependence that made early-bird, intent amount, replay, sync, and loopback E2E tests fail after the event cutoff
- preserves the production pricing rule: the 06:00 cutoff remains authoritative; only test clocks changed

## Why

`main` already contained the complete bot `dev` feature set, but the release verification exposed eight date-sensitive bridge failures once wall-clock time moved past the configured cutoff. This commit makes the safety suite deterministic before the next prod deploy.

## Checks

- `777 passed`
- coverage `55.92%` (required 40%)
- loopback website bridge E2E `7 passed`
- Ruff check: passed
- `git diff --check origin/main...dev`

Merging still does not deploy the bot; prod requires an explicit Coolify deploy.
