### PR TITLE
Sync event registry identity evidence to website

### DIFF
--- a/docs/identity-evidence-sync.md
+++ b/docs/identity-evidence-sync.md
@@ -1,0 +1,28 @@
+# Event registry evidence in alumni verification
+
+The website's `/admin/verification` page can show the registration history and
+Telegram metadata already held by this bot. The sync copies both active
+`registered_users` and `deleted_users` as display-only evidence.
+
+- Stable key: Mongo registration `_id` as `(source_system, source_record_id)`.
+- Payload: event, full name, graduation year/class, participant type,
+  `telegram_id`, `@username`, city, registration/payment status and creation
+  time.
+- The website never converts this evidence into a `person_telegram_link` and
+  never auto-merges people. Name/year matches are admin hints only.
+- Repeated syncs are idempotent. The first sync runs on bot startup, then every
+  900 seconds by default.
+
+Configuration is fail-closed. The website must first have its additive
+`identity_evidence` migration and `IDENTITY_EVIDENCE_SYNC_ENABLED=1`. Then set
+on this bot:
+
+```dotenv
+IDENTITY_EVIDENCE_SYNC_ENABLED=true
+IDENTITY_EVIDENCE_SYNC_INTERVAL_SECONDS=900
+EVENT_PAYMENTS_WEBSITE_API_BASE_URL=https://146.school
+EVENT_PAYMENTS_WEBSITE_API_TOKEN=<same bearer configured on website>
+```
+
+This feature does not require `EVENT_PAYMENTS_BRIDGE_ENABLED`; payment and
+identity-evidence rollout gates are intentionally independent.

--- a/example.env
+++ b/example.env
@@ -43,6 +43,11 @@ EVENT_PAYMENTS_REMOTE_PRICING_ENABLED=false
 # EVENT_PAYMENTS_BOT_EVENT_ID=6a599a17a37724d81b7eadc3
 # EVENT_PAYMENTS_API_TIMEOUT_SECONDS=5
 # EVENT_PAYMENTS_SYNC_INTERVAL_SECONDS=15
+# Display-only registry evidence for the website alumni verification page.
+# Independent from payments; reuses the website URL/token above. The website
+# must have IDENTITY_EVIDENCE_SYNC_ENABLED=1 before this is enabled.
+IDENTITY_EVIDENCE_SYNC_ENABLED=false
+# IDENTITY_EVIDENCE_SYNC_INTERVAL_SECONDS=900
 # Local mock only (make mock-website-api) — loopback HTTP allowed; never Coolify:
 # EVENT_PAYMENTS_WEBSITE_API_BASE_URL=http://127.0.0.1:8765
 # EVENT_PAYMENTS_WEBSITE_API_TOKEN=test-dedicated-token

--- a/src/app.py
+++ b/src/app.py
@@ -104,6 +104,12 @@ class AppSettings(BaseSettings):
     event_payments_remote_pricing_enabled: bool = False
     event_payments_api_timeout_seconds: float = Field(default=5.0, gt=0, le=30)
     event_payments_sync_interval_seconds: float = Field(default=15.0, ge=5, le=300)
+    # Copy display-only registration evidence (name/year/@username/event) to
+    # the website verification UI. Independent from checkout/ticket flags and
+    # uses the same internal API base URL + bearer token.
+    identity_evidence_sync_enabled: bool = False
+    identity_evidence_sync_interval_seconds: float = Field(
+        default=900.0, ge=60, le=86400)
 
     # Read event calendar fields (name, date, venue, address) from the website's
     # PostgreSQL instead of the Mongo document, making the website the single
@@ -193,6 +199,7 @@ class App:
         self._export_debounce_task: asyncio.Task | None = None
         self._export_debounce_seconds = 30
         self._event_payment_sync_task: asyncio.Task | None = None
+        self._identity_evidence_sync_task: asyncio.Task | None = None
         self._website_events = None
 
     async def startup(self):
@@ -230,16 +237,30 @@ class App:
                 run_payment_sync_loop(self), name="event-payment-sync"
             )
 
+        from src.identity_evidence_sync import (
+            identity_evidence_sync_requested,
+            run_identity_evidence_sync_loop,
+        )
+
+        if (identity_evidence_sync_requested(self.settings)
+                and self._identity_evidence_sync_task is None):
+            self._identity_evidence_sync_task = asyncio.create_task(
+                run_identity_evidence_sync_loop(self),
+                name="identity-evidence-sync",
+            )
+
     async def shutdown(self):
         """Stop background bridge work without delaying bot shutdown."""
-        task = self._event_payment_sync_task
+        tasks = [self._event_payment_sync_task, self._identity_evidence_sync_task]
         self._event_payment_sync_task = None
-        if task is not None:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        self._identity_evidence_sync_task = None
+        for task in tasks:
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
         reader = self._website_events
         self._website_events = None

--- a/src/app.py
+++ b/src/app.py
@@ -109,7 +109,8 @@ class AppSettings(BaseSettings):
     # uses the same internal API base URL + bearer token.
     identity_evidence_sync_enabled: bool = False
     identity_evidence_sync_interval_seconds: float = Field(
-        default=900.0, ge=60, le=86400)
+        default=900.0, ge=60, le=86400
+    )
 
     # Read event calendar fields (name, date, venue, address) from the website's
     # PostgreSQL instead of the Mongo document, making the website the single
@@ -242,8 +243,10 @@ class App:
             run_identity_evidence_sync_loop,
         )
 
-        if (identity_evidence_sync_requested(self.settings)
-                and self._identity_evidence_sync_task is None):
+        if (
+            identity_evidence_sync_requested(self.settings)
+            and self._identity_evidence_sync_task is None
+        ):
             self._identity_evidence_sync_task = asyncio.create_task(
                 run_identity_evidence_sync_loop(self),
                 name="identity-evidence-sync",

--- a/src/identity_evidence_sync.py
+++ b/src/identity_evidence_sync.py
@@ -53,8 +53,11 @@ def _item(registration: dict, event_names: dict[str, str], *, active: bool):
     if isinstance(year, bool) or not isinstance(year, int) or not 1900 <= year <= 2100:
         year = None
     telegram_id = registration.get("user_id")
-    if (isinstance(telegram_id, bool) or not isinstance(telegram_id, int)
-            or telegram_id < 1):
+    if (
+        isinstance(telegram_id, bool)
+        or not isinstance(telegram_id, int)
+        or telegram_id < 1
+    ):
         telegram_id = None
     event_id = _clean(registration.get("event_id"), 120)
     return IdentityEvidenceItem(
@@ -105,10 +108,10 @@ async def sync_identity_evidence_once(
     api = client or WebsiteEventBridgeClient(app.settings)
     synced = 0
     for start in range(0, len(items), 500):
-        batch = items[start:start + 500]
-        response = await api.sync_identity_evidence([
-            item.model_dump(mode="json") for item in batch
-        ])
+        batch = items[start : start + 500]
+        response = await api.sync_identity_evidence(
+            [item.model_dump(mode="json") for item in batch]
+        )
         if response.get("total") != len(batch):
             raise WebsiteBridgeError("identity_sync_count_mismatch")
         synced += len(batch)
@@ -126,4 +129,3 @@ async def run_identity_evidence_sync_loop(app: Any) -> None:
         except Exception:
             logger.exception("Identity evidence sync failed unexpectedly")
         await asyncio.sleep(interval)
-

--- a/src/identity_evidence_sync.py
+++ b/src/identity_evidence_sync.py
@@ -1,0 +1,129 @@
+"""Periodic, idempotent registry-bot identity evidence sync to 146.school."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+from bson import ObjectId
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from src.website_event_bridge import WebsiteBridgeError, WebsiteEventBridgeClient
+
+
+class IdentityEvidenceItem(BaseModel):
+    source_system: str = "club146_registry_bot"
+    source_record_id: str = Field(min_length=8, max_length=120)
+    event_external_id: str = Field(default="", max_length=120)
+    event_name: str = Field(default="", max_length=255)
+    full_name: str = Field(min_length=1, max_length=255)
+    graduation_year: int | None = Field(default=None, ge=1900, le=2100)
+    class_letter: str = Field(default="", max_length=8)
+    participant_type: str = Field(default="", max_length=32)
+    telegram_id: int | None = Field(default=None, ge=1)
+    telegram_username: str = Field(default="", max_length=64)
+    city: str = Field(default="", max_length=120)
+    registration_status: str
+    payment_status: str = Field(default="", max_length=24)
+    source_created_at: datetime | None = None
+
+
+def identity_evidence_sync_requested(settings: Any) -> bool:
+    return getattr(settings, "identity_evidence_sync_enabled", False) is True
+
+
+def _clean(value: Any, limit: int) -> str:
+    return " ".join(str(value or "").split())[:limit]
+
+
+def _source_created_at(value: Any) -> datetime | None:
+    if isinstance(value, ObjectId):
+        return value.generation_time.astimezone(timezone.utc)
+    return None
+
+
+def _item(registration: dict, event_names: dict[str, str], *, active: bool):
+    record_id = registration.get("_id")
+    full_name = _clean(registration.get("full_name"), 255)
+    if not record_id or not full_name:
+        return None
+    year = registration.get("graduation_year")
+    if isinstance(year, bool) or not isinstance(year, int) or not 1900 <= year <= 2100:
+        year = None
+    telegram_id = registration.get("user_id")
+    if (isinstance(telegram_id, bool) or not isinstance(telegram_id, int)
+            or telegram_id < 1):
+        telegram_id = None
+    event_id = _clean(registration.get("event_id"), 120)
+    return IdentityEvidenceItem(
+        source_record_id=_clean(record_id, 120),
+        event_external_id=event_id,
+        event_name=_clean(event_names.get(event_id), 255),
+        full_name=full_name,
+        graduation_year=year,
+        class_letter=_clean(registration.get("class_letter"), 8),
+        participant_type=_clean(registration.get("graduate_type"), 32),
+        telegram_id=telegram_id,
+        telegram_username=_clean(registration.get("username"), 64).lstrip("@"),
+        city=_clean(registration.get("target_city"), 120),
+        registration_status="active" if active else "deleted",
+        payment_status=_clean(registration.get("payment_status"), 24),
+        source_created_at=_source_created_at(record_id),
+    )
+
+
+async def build_identity_evidence(app: Any) -> list[IdentityEvidenceItem]:
+    events = await app.events_col.find({}).to_list(length=None)
+    event_names = {
+        str(event.get("_id")): _clean(event.get("name"), 255)
+        for event in events
+        if event.get("_id")
+    }
+    active = await app.collection.find({}).to_list(length=None)
+    deleted = await app.deleted_users.find({}).to_list(length=None)
+    items = [
+        item
+        for registration, is_active in (
+            *((registration, True) for registration in active),
+            *((registration, False) for registration in deleted),
+        )
+        if (item := _item(registration, event_names, active=is_active)) is not None
+    ]
+    return items
+
+
+async def sync_identity_evidence_once(
+    app: Any,
+    *,
+    client: WebsiteEventBridgeClient | None = None,
+) -> int:
+    if not identity_evidence_sync_requested(app.settings):
+        return 0
+    items = await build_identity_evidence(app)
+    api = client or WebsiteEventBridgeClient(app.settings)
+    synced = 0
+    for start in range(0, len(items), 500):
+        batch = items[start:start + 500]
+        response = await api.sync_identity_evidence([
+            item.model_dump(mode="json") for item in batch
+        ])
+        if response.get("total") != len(batch):
+            raise WebsiteBridgeError("identity_sync_count_mismatch")
+        synced += len(batch)
+    logger.info("Synced {} registry identity evidence rows to website", synced)
+    return synced
+
+
+async def run_identity_evidence_sync_loop(app: Any) -> None:
+    interval = float(app.settings.identity_evidence_sync_interval_seconds)
+    while True:
+        try:
+            await sync_identity_evidence_once(app)
+        except WebsiteBridgeError as exc:
+            logger.error("Identity evidence sync failed: {}", exc.code)
+        except Exception:
+            logger.exception("Identity evidence sync failed unexpectedly")
+        await asyncio.sleep(interval)
+

--- a/src/website_event_bridge.py
+++ b/src/website_event_bridge.py
@@ -696,6 +696,11 @@ class WebsiteEventBridgeClient:
     async def create_or_replay(self, payload: dict) -> dict:
         return await self._post("/api/internal/event-payment-intents", payload)
 
+    async def sync_identity_evidence(self, items: list[dict]) -> dict:
+        """Store display-only registration evidence; never creates TG links."""
+        return await self._post(
+            "/api/internal/identity-evidence/batch", {"items": items})
+
     async def get_event_config(self, bot_event_id: str) -> dict:
         """Read this bot event's pricing config from the website."""
         event = quote(bot_event_id, safe="")

--- a/src/website_event_bridge.py
+++ b/src/website_event_bridge.py
@@ -699,7 +699,8 @@ class WebsiteEventBridgeClient:
     async def sync_identity_evidence(self, items: list[dict]) -> dict:
         """Store display-only registration evidence; never creates TG links."""
         return await self._post(
-            "/api/internal/identity-evidence/batch", {"items": items})
+            "/api/internal/identity-evidence/batch", {"items": items}
+        )
 
     async def get_event_config(self, bot_event_id: str) -> dict:
         """Read this bot event's pricing config from the website."""

--- a/tests/test_identity_evidence_sync.py
+++ b/tests/test_identity_evidence_sync.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import pytest
+from bson import ObjectId
+
+from src.identity_evidence_sync import (
+    build_identity_evidence,
+    sync_identity_evidence_once,
+)
+from src.website_event_bridge import WebsiteBridgeError
+
+
+class Cursor:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def to_list(self, length=None):
+        return self.rows
+
+
+class Collection:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def find(self, query):
+        assert query == {}
+        return Cursor(self.rows)
+
+
+class Client:
+    def __init__(self):
+        self.batches = []
+
+    async def sync_identity_evidence(self, items):
+        self.batches.append(items)
+        return {"created": len(items), "updated": 0, "total": len(items)}
+
+
+def app(*, enabled=True):
+    event_id = ObjectId("6a599a17a37724d81b7eadc3")
+    active_id = ObjectId("67ca89364841b89f8164ae1d")
+    deleted_id = ObjectId("67e2108711c707f46cb8e161")
+    return SimpleNamespace(
+        settings=SimpleNamespace(identity_evidence_sync_enabled=enabled),
+        events_col=Collection([{"_id": event_id, "name": "Летняя встреча"}]),
+        collection=Collection([{
+            "_id": active_id,
+            "event_id": str(event_id),
+            "full_name": "  Пушкарева   Диана Владимировна ",
+            "graduation_year": 2009,
+            "class_letter": "А",
+            "graduate_type": "GRADUATE",
+            "user_id": 123456,
+            "username": "@diana_tg",
+            "target_city": "Пермь",
+            "payment_status": "confirmed",
+        }]),
+        deleted_users=Collection([{
+            "_id": deleted_id,
+            "full_name": "Хисамутдинов Айрат Альбертович",
+            "graduation_year": 2012,
+            "class_letter": "Б",
+            "user_id": 654321,
+            "username": "RaccoonTunTun",
+        }]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_builds_active_and_deleted_evidence_without_linking_people():
+    items = await build_identity_evidence(app())
+
+    assert len(items) == 2
+    active, deleted = items
+    assert active.full_name == "Пушкарева Диана Владимировна"
+    assert active.event_name == "Летняя встреча"
+    assert active.telegram_username == "diana_tg"
+    assert active.registration_status == "active"
+    assert active.source_created_at is not None
+    assert deleted.registration_status == "deleted"
+
+
+@pytest.mark.asyncio
+async def test_sync_is_idempotent_batch_contract_and_disabled_by_default():
+    client = Client()
+    assert await sync_identity_evidence_once(app(enabled=False), client=client) == 0
+    assert client.batches == []
+
+    assert await sync_identity_evidence_once(app(), client=client) == 2
+    assert len(client.batches) == 1
+    assert client.batches[0][0]["source_system"] == "club146_registry_bot"
+    assert "person_id" not in client.batches[0][0]
+
+
+@pytest.mark.asyncio
+async def test_count_mismatch_fails_closed():
+    class BadClient(Client):
+        async def sync_identity_evidence(self, items):
+            return {"total": 0}
+
+    with pytest.raises(WebsiteBridgeError, match="identity_sync_count_mismatch"):
+        await sync_identity_evidence_once(app(), client=BadClient())
+


### PR DESCRIPTION
## Outcome\n- sync active and deleted bot registrations as display-only verification evidence\n- include event, name/year/class, Telegram ID/@username, city and statuses\n- idempotent batches; disabled by default and independent from payments\n- never creates person_telegram_links or auto-merges\n\n## Verification\n- 780 passed\n- ruff and compileall clean