### PR TITLE
payments: preserve receipt evidence and safe proof retention

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -75,7 +75,6 @@ jobs:
   complexity:
     name: Complexity (advisory)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -91,4 +90,5 @@ jobs:
         run: uv sync --all-groups
 
       - name: Run Lizard complexity check
+        continue-on-error: true
         run: uv run lizard -l python --CCN 15 -w src

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Deploy: prod does NOT auto-deploy — merging to `main` ships nothing. Always finish with `make deploy-prod` (or `make release-prod`, which includes it). Cause: prod app is on Coolify `source_id=2` (calmmage GitHub App), not 4 (Club-146), so no push webhook ever arrives; failure is silent, prod just keeps serving the old image. Never tell the user a merge is live — check `deployments/applications/raa8wuc20q0leqf7svr2tj83` and the `Europe/Moscow` line in `src.reminder_scheduler` startup logs. `scripts/coolify-deploy.sh`, `docs/DEPLOY.md`.
 
+Production data / payment reconciliation: bot registrations are in the prod MongoDB behind Coolify app `raa8wuc20q0leqf7svr2tj83`; website payments are separate in Yandex PostgreSQL. Never print Mongo connection env values. Use the running app container for read-only `pymongo` exports, and use `~/work/projects/146.school/scripts/db/prod-ro.sh` (`club146_ai_ro`) for website reads. Full runbook and reconciliation caveats: `docs/PRODUCTION_DATA_ACCESS.md`.
+
+Payment-proof retention: long-term deletion requires a dedicated proof-review chat; never enable chat-wide auto-delete on `EVENTS_CHAT_ID`. Configure `PAYMENT_PROOFS_CHAT_ID`; policy and legacy-cleanup boundary: `docs/PAYMENT_PROOF_RETENTION.md`.
+
 Campaign / UTM-like attribution (CRM-ish): Telegram deep links only — `t.me/<bot>?start={source}__{campaign}[__{content}]`. Classic `?utm_*=` on bot URLs does nothing. Parser + store: `App.parse_start_attribution` / `record_start_source` / `user_sources`; /start extract in `router.extract_start_payload`; registration stamps `RegisteredUser.start_source`; admin `/source_stats`. Full note: `docs/start-source-attribution.md`. Outbound mailers (e.g. 146.school event_announce) must put payload in `?start=`, not site UTM.
 
 Imports
@@ -81,4 +85,3 @@ uv for python:
 - CLIs with `typer`;
 - Keep `cli.py` colocated under each tool directory.
 - Provide short docstrings and a quick usage example per command.
-

--- a/docs/PAYMENT_PROOF_RETENTION.md
+++ b/docs/PAYMENT_PROOF_RETENTION.md
@@ -1,0 +1,21 @@
+# Payment-proof retention
+
+Policy: copied payment screenshots and PDFs are retained for at most 365 days.
+Registration, amount, payment method, verification time, provider transaction
+ID, and audit-log metadata are retained; the proof media itself is not.
+
+Telegram's Bot API can delete an individual message only during the first 48
+hours.  Its long-term auto-delete timer applies to every message in a chat, not
+only media.  Therefore payment proofs must use a dedicated review chat:
+
+1. Create a private admin chat used only for payment proofs.
+2. Add the bot as an administrator with permission to manage auto-delete.
+3. Set `PAYMENT_PROOFS_CHAT_ID` to that chat.  It must differ from
+   `EVENTS_CHAT_ID`.
+4. Keep `PAYMENT_PROOF_RETENTION_DAYS=365` (the default).
+
+On startup the bot configures the dedicated chat's auto-delete timer and sends
+new proofs there.  If the dedicated chat is missing or equals the events chat,
+retention is refused and current routing remains unchanged.  Enabling the timer
+is not retroactive: legacy proofs in the shared events chat require a one-time
+admin-client cleanup after they cross the one-year cutoff.

--- a/docs/PRODUCTION_DATA_ACCESS.md
+++ b/docs/PRODUCTION_DATA_ACCESS.md
@@ -1,0 +1,36 @@
+# Production registration and payment data
+
+The production event registry and the website payment ledger are separate systems:
+
+| Source | Live store | Safe read path |
+| --- | --- | --- |
+| Registration bot | MongoDB used by Coolify app `raa8wuc20q0leqf7svr2tj83` on `new-c.calmmage.com` | Run a read-only `pymongo` query/export inside the current app container, using its existing env without printing it |
+| 146.school | Yandex Managed PostgreSQL | `cd ~/work/projects/146.school && ./scripts/db/prod-ro.sh ...` (`club146_ai_ro`, SELECT-only) |
+
+The website PostgreSQL path was already documented in `~/work/projects/146.school/docs/prod-db-read-access.md` and implemented by `scripts/db/prod-ro.sh`. The missing piece was a bot-side pointer and the cross-system reconciliation boundary.
+
+For MongoDB, resolve the current container by the stable Coolify application prefix; the deployment suffix changes:
+
+```bash
+ssh root@new-c.calmmage.com \
+  'docker ps --format "{{.Names}}" | grep "^raa8wuc20q0leqf7svr2tj83-"'
+```
+
+Inside that container, use `uv run python` + `pymongo.MongoClient` with `BOTSPOT_MONGO_DATABASE_CONN_STR` and `BOTSPOT_MONGO_DATABASE_DATABASE`. Do not echo, inspect, copy, or log either value. Queries must be reads only. Important collections:
+
+- `events` — event identity and pricing;
+- `registered_users` — current registrations, guests, payment status/amount/method;
+- `deleted_users` — cancelled registration history;
+- `event_logs` — payment and deletion transitions;
+- export all collections when a complete audit is requested, not only the four above.
+
+Reconciliation rules:
+
+- `payment_method=to_maria` is only a bot claim. It cannot be independently verified from the website database; Maria's bank statement is a separate source.
+- Website event-payment tables are `event_payment_intents`, `event_admissions`, and `event_payment_audit_events`, separate from `donations` and `subscriptions`.
+- As observed on 2026-08-03, those three event-payment tables had zero production rows. Historical website payment matching therefore used `donations`.
+- Production `donations.event_id` was blank for the relevant CloudPayments rows. A match by person + time + exact allowed amount is evidence-backed inference, not a registration-bound provider record.
+- People are duplicated in the website database. Do not join on one `person_id` alone; reconcile duplicate identities using strong identifiers (Telegram/email/phone, then full name) and account for every website payment row exactly once.
+- A bot `confirmed` status is not proof of a website payment. Compare the successful CloudPayments amount with the bot's recorded amount and the event's regular/early-bird total, including guests.
+
+Exports contain real PII. Keep local directories `0700`, files `0600`, never commit them, and remove remote temporary copies immediately after download and checksum verification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "register-146-meetup-2025-bot"
-version = "0.2.4"
+version = "0.2.5"
 description = ""
 readme = "README.md"
 authors = [

--- a/src/app.py
+++ b/src/app.py
@@ -76,6 +76,10 @@ class AppSettings(BaseSettings):
     spreadsheet_id: Optional[str] = None
     logs_chat_id: Optional[int] = None
     events_chat_id: int
+    # Payment-proof media needs a dedicated review chat so Telegram's chat-wide
+    # auto-delete timer does not erase registration and event audit messages.
+    payment_proofs_chat_id: Optional[int] = None
+    payment_proof_retention_days: int = Field(default=365, ge=1, le=365)
     payment_phone_number: str
     payment_name: str
     # Personal /donate pay links. Prod default; override on Coolify dev if needed.
@@ -1305,6 +1309,9 @@ class App:
         payment_status: Optional[str] = None,
         payment_method: Optional[str] = None,
         payment_method_source: Optional[str] = None,
+        payment_method_claimed: Optional[str] = None,
+        payment_proof_analysis: Optional[dict] = None,
+        payment_method_override: Optional[dict] = None,
     ):
         """
         Save payment information for a user
@@ -1318,8 +1325,11 @@ class App:
             formula_amount: The payment amount calculated by formula
             username: Optional user's Telegram username for logging
             payment_status: Payment status (pending, confirmed, None for just registered)
-            payment_method: ``on_site`` | ``to_maria`` when known
-            payment_method_source: ``user`` | ``ai`` | etc.
+            payment_method: ``on_site`` | ``to_admin`` (``to_maria`` is legacy)
+            payment_method_source: ``user`` | ``proof_recipient`` | etc.
+            payment_method_claimed: What the participant selected before proof parsing
+            payment_proof_analysis: Structured receipt evidence retained for admin audit
+            payment_method_override: Evidence-backed method correction metadata
         """
         # Update the user's registration with payment info
         update_data = {
@@ -1337,6 +1347,12 @@ class App:
             update_data["payment_method"] = payment_method
         if payment_method_source is not None:
             update_data["payment_method_source"] = payment_method_source
+        if payment_method_claimed is not None:
+            update_data["payment_method_claimed"] = payment_method_claimed
+        if payment_proof_analysis is not None:
+            update_data["payment_proof_analysis"] = payment_proof_analysis
+        if payment_method_override is not None:
+            update_data["payment_method_override"] = payment_method_override
 
         # Get user registration for logging
         user_data = await self.collection.find_one(
@@ -1359,6 +1375,17 @@ class App:
             log_data["payment_method"] = payment_method
         if payment_method_source is not None:
             log_data["payment_method_source"] = payment_method_source
+        if payment_method_claimed is not None:
+            log_data["payment_method_claimed"] = payment_method_claimed
+        if payment_proof_analysis is not None:
+            log_data["payment_proof_destination"] = payment_proof_analysis.get(
+                "destination"
+            )
+            log_data["payment_proof_status"] = payment_proof_analysis.get(
+                "receipt_status"
+            )
+        if payment_method_override is not None:
+            log_data["payment_method_override"] = payment_method_override
 
         await self.save_event_log("payment_info", log_data, user_id, username)
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -49,6 +49,13 @@ def main(debug=False) -> None:
     async def on_startup() -> None:
         await app.startup()
         try:
+            from src.payment_proof_retention import configure_payment_proof_retention
+
+            await configure_payment_proof_retention(bot, app.settings)
+        except Exception:
+            logger.exception("Failed to configure payment-proof retention")
+
+        try:
             from src.reminder_scheduler import start_reminder_scheduler
 
             start_reminder_scheduler(app, bot)

--- a/src/payment_proof_analysis.py
+++ b/src/payment_proof_analysis.py
@@ -1,0 +1,296 @@
+"""Structured receipt analysis and evidence-first payment-method resolution."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import unicodedata
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+
+from litellm import acompletion
+from loguru import logger
+from pydantic import BaseModel
+
+
+DEFAULT_PAYMENT_PARSE_MODEL = "anthropic/claude-sonnet-4-6"
+ANALYZER_VERSION = "receipt-destination-v2"
+
+
+class PaymentDestination(str, Enum):
+    EVENT_ADMIN = "event_admin"
+    WEBSITE = "website"
+    UNKNOWN = "unknown"
+
+
+class ReceiptStatus(str, Enum):
+    SUCCEEDED = "succeeded"
+    PENDING = "pending"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+class PaymentRecipient(BaseModel):
+    name: str = ""
+    phone: str = ""
+    label: str = "event admin"
+
+
+class PaymentInfo(BaseModel):
+    amount: Optional[int] = None
+    is_valid: bool = False
+    destination: PaymentDestination = PaymentDestination.UNKNOWN
+    receipt_status: ReceiptStatus = ReceiptStatus.UNKNOWN
+    recipient_name: Optional[str] = None
+    recipient_phone: Optional[str] = None
+    merchant_name: Optional[str] = None
+    matched_admin: Optional[str] = None
+    method_reason: Optional[str] = None
+
+    @property
+    def payment_method(self) -> str | None:
+        if self.destination == PaymentDestination.EVENT_ADMIN:
+            return "to_admin"
+        if self.destination == PaymentDestination.WEBSITE:
+            return "on_site"
+        return None
+
+    @property
+    def paid_to_maria(self) -> bool:
+        """Compatibility for old display call sites; new storage uses to_admin."""
+        return self.destination == PaymentDestination.EVENT_ADMIN
+
+
+class PaymentMethodResolution(BaseModel):
+    claimed_method: str | None
+    proof_method: str | None
+    effective_method: str | None
+    source: str | None
+    overridden: bool = False
+    override_reason: str | None = None
+
+
+def _normalise_text(value: Any) -> str:
+    text = unicodedata.normalize("NFKC", str(value or "")).lower().replace("ё", "е")
+    return " ".join(re.findall(r"[a-zа-я0-9]+", text))
+
+
+def _phone_digits(value: Any) -> str:
+    digits = re.sub(r"\D", "", str(value or ""))
+    if len(digits) == 11 and digits[0] in "78":
+        return digits[-10:]
+    return digits
+
+
+def _name_matches(receipt_name: str, configured_name: str) -> bool:
+    receipt = _normalise_text(receipt_name)
+    configured = _normalise_text(configured_name)
+    if not receipt or not configured:
+        return False
+    if receipt == configured or receipt in configured or configured in receipt:
+        return True
+    receipt_tokens = receipt.split()
+    configured_tokens = configured.split()
+    if not receipt_tokens or not configured_tokens:
+        return False
+    first_name_matches = receipt_tokens[0] == configured_tokens[0]
+    surname_initial_matches = receipt_tokens[-1][0] == configured_tokens[-1][0]
+    return first_name_matches and surname_initial_matches
+
+
+def configured_payment_recipients(
+    settings: Any, event: dict | None = None
+) -> list[PaymentRecipient]:
+    """Return event-specific recipients, falling back to the legacy Maria env pair."""
+    raw = (event or {}).get("payment_recipients")
+    recipients: list[PaymentRecipient] = []
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            recipient = PaymentRecipient.model_validate(item)
+            if recipient.name.strip() or recipient.phone.strip():
+                recipients.append(recipient)
+    if recipients:
+        return recipients
+
+    name = str(getattr(settings, "payment_name", "") or "").strip()
+    phone = str(getattr(settings, "payment_phone_number", "") or "").strip()
+    if name or phone:
+        return [PaymentRecipient(name=name, phone=phone, label=name or "event admin")]
+    return []
+
+
+def _match_admin_recipient(
+    info: PaymentInfo, recipients: list[PaymentRecipient]
+) -> PaymentRecipient | None:
+    observed_phone = _phone_digits(info.recipient_phone)
+    for recipient in recipients:
+        configured_phone = _phone_digits(recipient.phone)
+        if observed_phone and configured_phone and observed_phone == configured_phone:
+            return recipient
+        if info.recipient_name and _name_matches(info.recipient_name, recipient.name):
+            return recipient
+    return None
+
+
+def validate_destination(
+    info: PaymentInfo, recipients: list[PaymentRecipient]
+) -> PaymentInfo:
+    """Require extracted recipient evidence before accepting an admin destination."""
+    matched = _match_admin_recipient(info, recipients)
+    if matched:
+        reason = (
+            info.method_reason or "receipt recipient matches configured event admin"
+        )
+        return info.model_copy(
+            update={
+                "destination": PaymentDestination.EVENT_ADMIN,
+                "matched_admin": matched.label,
+                "method_reason": reason,
+            }
+        )
+    if info.destination == PaymentDestination.EVENT_ADMIN:
+        return info.model_copy(
+            update={
+                "destination": PaymentDestination.UNKNOWN,
+                "matched_admin": None,
+                "method_reason": "admin destination rejected: recipient does not match configuration",
+            }
+        )
+    return info
+
+
+def resolve_payment_method(
+    claimed_method: str | None,
+    claimed_source: str | None,
+    info: PaymentInfo,
+) -> PaymentMethodResolution:
+    """Positive receipt evidence for an admin overrides a website button click."""
+    canonical_claim = "to_admin" if claimed_method == "to_maria" else claimed_method
+    proof_method = info.payment_method
+    if proof_method == "to_admin":
+        overridden = canonical_claim not in (None, "to_admin")
+        return PaymentMethodResolution(
+            claimed_method=canonical_claim,
+            proof_method=proof_method,
+            effective_method="to_admin",
+            source="proof_recipient",
+            overridden=overridden,
+            override_reason="configured_event_admin_recipient" if overridden else None,
+        )
+    if canonical_claim in ("on_site", "to_admin"):
+        return PaymentMethodResolution(
+            claimed_method=canonical_claim,
+            proof_method=proof_method,
+            effective_method=canonical_claim,
+            source=claimed_source or "user",
+        )
+    if proof_method == "on_site":
+        return PaymentMethodResolution(
+            claimed_method=None,
+            proof_method=proof_method,
+            effective_method="on_site",
+            source="proof_merchant",
+        )
+    return PaymentMethodResolution(
+        claimed_method=canonical_claim,
+        proof_method=proof_method,
+        effective_method=None,
+        source=None,
+    )
+
+
+def proof_analysis_payload(
+    info: PaymentInfo, resolution: PaymentMethodResolution
+) -> dict[str, Any]:
+    return {
+        "analyzer_version": ANALYZER_VERSION,
+        "analyzed_at": datetime.now(timezone.utc).isoformat(),
+        **info.model_dump(mode="json"),
+        "claimed_method": resolution.claimed_method,
+        "proof_method": resolution.proof_method,
+        "effective_method": resolution.effective_method,
+        "method_source": resolution.source,
+        "overridden": resolution.overridden,
+        "override_reason": resolution.override_reason,
+    }
+
+
+async def extract_payment_from_image(
+    file_bytes: bytes,
+    file_type: str = "image/jpeg",
+    *,
+    recipients: list[PaymentRecipient] | None = None,
+    recipient_name: str | None = None,
+    recipient_phone: str | None = None,
+    model: str | None = None,
+) -> PaymentInfo:
+    """Extract amount, status, merchant, and actual recipient from a receipt."""
+    try:
+        configured = list(recipients or [])
+        if not configured and (recipient_name or recipient_phone):
+            configured = [
+                PaymentRecipient(
+                    name=(recipient_name or "").strip(),
+                    phone=(recipient_phone or "").strip(),
+                    label=(recipient_name or "event admin").strip(),
+                )
+            ]
+        recipient_lines = (
+            "\n".join(
+                f"- {recipient.label}: name={recipient.name or '(none)'}, phone={recipient.phone or '(none)'}"
+                for recipient in configured
+            )
+            or "- none configured"
+        )
+        system_prompt = f"""You analyze Russian payment receipts for an event.
+Extract only what is visible in the receipt:
+- amount: integer rubles, or null
+- is_valid: whether one clear payment amount is visible
+- destination: event_admin | website | unknown
+- receipt_status: succeeded | pending | failed | unknown
+- recipient_name and recipient_phone exactly as shown, when present
+- merchant_name exactly as shown, when present
+- method_reason: one short evidence phrase
+
+Configured event-admin recipients:
+{recipient_lines}
+
+Use destination=event_admin only when the receipt's recipient fields match a
+configured admin. Use destination=website for a merchant/card/acquiring payment
+such as 146.school or CloudPayments. Use unknown when cropped or ambiguous.
+Do not infer success from the presence of an amount: preserve pending/failed status."""
+
+        if file_type not in {"image/jpeg", "image/png", "application/pdf"}:
+            raise ValueError(f"Unsupported file type: {file_type}")
+        encoded_file = base64.b64encode(file_bytes).decode("utf-8")
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Extract receipt amount, status, merchant, and actual recipient.",
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{file_type};base64,{encoded_file}"},
+                    },
+                ],
+            },
+        ]
+        response = await acompletion(
+            model=model or DEFAULT_PAYMENT_PARSE_MODEL,
+            messages=messages,
+            max_tokens=300,
+            response_format=PaymentInfo,
+        )
+        parsed = PaymentInfo(**json.loads(response.choices[0].message.content))  # type: ignore[union-attr]
+        return validate_destination(parsed, configured)
+    except Exception as exc:
+        logger.error(f"Error extracting payment proof: {exc}")
+        return PaymentInfo()

--- a/src/payment_proof_retention.py
+++ b/src/payment_proof_retention.py
@@ -1,0 +1,42 @@
+"""Telegram-side retention for copied payment-proof media."""
+
+from __future__ import annotations
+
+from aiogram import Bot
+from loguru import logger
+
+from src.app import AppSettings
+
+
+SECONDS_PER_DAY = 86_400
+
+
+async def configure_payment_proof_retention(
+    bot: Bot,
+    settings: AppSettings,
+) -> bool:
+    """Enable chat-wide retention only on an explicitly dedicated proof chat."""
+    proof_chat_id = settings.payment_proofs_chat_id
+    if proof_chat_id is None:
+        logger.warning(
+            "Payment-proof retention is not active: PAYMENT_PROOFS_CHAT_ID is unset"
+        )
+        return False
+    if proof_chat_id == settings.events_chat_id:
+        logger.error(
+            "Payment-proof retention refused: PAYMENT_PROOFS_CHAT_ID must differ "
+            "from EVENTS_CHAT_ID because Telegram auto-delete is chat-wide"
+        )
+        return False
+
+    retention_seconds = settings.payment_proof_retention_days * SECONDS_PER_DAY
+    await bot.set_chat_message_auto_delete_time(
+        chat_id=proof_chat_id,
+        message_auto_delete_time=retention_seconds,
+    )
+    logger.info(
+        "Payment-proof retention active: chat={} days={}",
+        proof_chat_id,
+        settings.payment_proof_retention_days,
+    )
+    return True

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -1,5 +1,5 @@
-import base64
-import json
+from datetime import datetime, timezone
+from html import escape
 from typing import Mapping, Optional
 
 from aiogram import Router
@@ -8,10 +8,14 @@ from aiogram.fsm.context import FSMContext
 from aiogram.types import (
     Message,
 )
-from litellm import acompletion
 from loguru import logger
-from pydantic import BaseModel
 from src.app import App, GraduateType, RegisteredUser
+from src.payment_proof_analysis import (
+    PaymentDestination,
+    ReceiptStatus,
+    configured_payment_recipients,
+    extract_payment_from_image,
+)
 from src.ticket_cards import send_paid_ticket_card
 from src.website_event_bridge import (
     WebsiteBridgeError,
@@ -29,25 +33,6 @@ from botspot.utils import send_safe
 from botspot.utils.admin_filter import AdminFilter
 
 
-# Define Pydantic model for payment information
-class PaymentInfo(BaseModel):
-    amount: Optional[int]
-    is_valid: bool  # Whether there's a clear payment amount in the document
-    # True if receipt looks like a transfer to Maria (name/phone from env).
-    # False → treat as website / card payment (CloudPayments, etc.).
-    paid_to_maria: bool = False
-    method_reason: Optional[str] = None  # short free-text evidence for admins/logs
-
-    @property
-    def payment_method(self) -> str:
-        """Canonical method key used elsewhere: on_site | to_maria."""
-        return "to_maria" if self.paid_to_maria else "on_site"
-
-
-# Sonnet: Haiku was cheaper but misclassified receipts; override via PAYMENT_PARSE_MODEL.
-DEFAULT_PAYMENT_PARSE_MODEL = "anthropic/claude-sonnet-4-6"
-
-
 router = Router()
 
 
@@ -61,6 +46,7 @@ _ADMIN_SUBMENUS = {
             "manage_events": "Управление встречами",
             "manual_register": "Зарегистрировать человека вручную",
             "register_payment": "Зарегистрировать оплату (за другого участника)",
+            "payment_audit": "Сверить чеки и способы оплаты",
             "discretionary": "Скидка / бесплатный вход (решение Марии)",
             "payment_reminders": "Напоминания об оплате (D-4 / D-2)",
             "export": "Экспортировать данные",
@@ -118,6 +104,8 @@ async def _dispatch_admin_action(
         await admin_manual_register(message, state, app)
     elif response == "register_payment":
         await admin_register_payment(message, state, app)
+    elif response == "payment_audit":
+        await admin_payment_audit(message, state, app)
     elif response == "discretionary":
         await admin_discretionary_payment(message, state, app)
     elif response == "payment_reminders":
@@ -624,6 +612,147 @@ async def admin_register_payment(message: Message, state: FSMContext, app: App):
     await app.export_registered_users_to_google_sheets()
 
 
+def _proof_audit_problem(registration: dict, *, bridge_active: bool) -> str | None:
+    analysis = registration.get("payment_proof_analysis")
+    if not isinstance(analysis, dict):
+        return (
+            "нет сохранённого анализа чека"
+            if registration.get("payment_screenshot_id")
+            else None
+        )
+
+    destination = analysis.get("destination")
+    method = registration.get("payment_method")
+    receipt_status = analysis.get("receipt_status")
+    if receipt_status == ReceiptStatus.PENDING.value:
+        return "чек pending — подтвердить зачисление"
+    if receipt_status == ReceiptStatus.FAILED.value:
+        return "чек неуспешный"
+    if destination == PaymentDestination.UNKNOWN.value:
+        return "получатель в чеке не распознан"
+    if destination == PaymentDestination.EVENT_ADMIN.value and method not in {
+        "to_admin",
+        "to_maria",
+    }:
+        return "чек администратору, но способ оплаты другой"
+    if destination == PaymentDestination.WEBSITE.value and method in {
+        "to_admin",
+        "to_maria",
+    }:
+        return "чек сайта, но запись говорит «администратору»"
+
+    bridge = registration.get("website_event_bridge")
+    if (
+        bridge_active
+        and method == "on_site"
+        and registration.get("payment_status") == "confirmed"
+        and isinstance(bridge, dict)
+        and bridge.get("remote_status") not in {"paid", "waived"}
+    ):
+        return "бот подтвердил сайт, но website ledger не paid"
+    return None
+
+
+@commands_menu.add_command(
+    "payment_audit",
+    "Сверить чеки и способы оплаты",
+    visibility=Visibility.ADMIN_ONLY,
+)
+@router.message(Command("payment_audit"), AdminFilter())
+async def admin_payment_audit(message: Message, state: FSMContext, app: App) -> None:
+    """Audit stored proof evidence and repair exact admin-recipient mismatches."""
+    event_id = await _select_event_for_payment(message.chat.id, state, app)
+    if not event_id:
+        return
+
+    registrations = await app.get_all_users(event_id=event_id)
+    bridge_active = bridge_requested(app.settings)
+    fixed: list[str] = []
+    for registration in registrations:
+        analysis = registration.get("payment_proof_analysis")
+        if not isinstance(analysis, dict):
+            continue
+        if analysis.get("destination") != PaymentDestination.EVENT_ADMIN.value:
+            continue
+        if registration.get("payment_method") in {"to_admin", "to_maria"}:
+            continue
+
+        now = datetime.now(timezone.utc).isoformat()
+        previous_method = registration.get("payment_method")
+        result = await app.collection.update_one(
+            {
+                "_id": registration["_id"],
+                "payment_method": previous_method,
+                "payment_proof_analysis.destination": PaymentDestination.EVENT_ADMIN.value,
+            },
+            {
+                "$set": {
+                    "payment_method": "to_admin",
+                    "payment_method_source": "admin_proof_audit",
+                    "payment_method_override": {
+                        "from": previous_method,
+                        "to": "to_admin",
+                        "reason": "configured_event_admin_recipient",
+                        "at": now,
+                    },
+                }
+            },
+        )
+        if result.modified_count != 1:
+            continue
+        registration["payment_method"] = "to_admin"
+        fixed.append(registration.get("full_name") or str(registration["_id"]))
+        await app.save_event_log(
+            "payment_correction",
+            {
+                "action": "payment_audit_recipient_override",
+                "event_id": event_id,
+                "registration_id": str(registration["_id"]),
+                "previous_method": previous_method,
+                "new_method": "to_admin",
+                "proof_message_id": registration.get("payment_screenshot_id"),
+            },
+            message.from_user.id if message.from_user else None,
+            message.from_user.username if message.from_user else None,
+        )
+
+    analyses = [
+        registration["payment_proof_analysis"]
+        for registration in registrations
+        if isinstance(registration.get("payment_proof_analysis"), dict)
+    ]
+    problems = []
+    for registration in registrations:
+        problem = _proof_audit_problem(registration, bridge_active=bridge_active)
+        if not problem:
+            continue
+        username = registration.get("username")
+        identity = registration.get("full_name") or str(registration.get("_id"))
+        if username:
+            identity += f" @{username}"
+        problems.append(f"• {identity}: {problem}")
+
+    destination_counts = {
+        destination.value: sum(
+            analysis.get("destination") == destination.value for analysis in analyses
+        )
+        for destination in PaymentDestination
+    }
+    result_text = (
+        f"🧾 Сверка чеков\n"
+        f"Регистраций: {len(registrations)} · чеков разобрано: {len(analyses)}\n"
+        f"Администратору: {destination_counts['event_admin']} · "
+        f"сайт: {destination_counts['website']} · "
+        f"неясно: {destination_counts['unknown']}\n"
+        f"Автоисправлено сейчас: {len(fixed)} · требует внимания: {len(problems)}"
+    )
+    if problems:
+        result_text += "\n\n" + "\n".join(problems[:30])
+        if len(problems) > 30:
+            result_text += f"\n…и ещё {len(problems) - 30}"
+    await send_safe(message.chat.id, result_text)
+
+
 async def _apply_admin_confirmed_payment(
     app: App,
     message: Message,
@@ -1081,89 +1210,6 @@ async def normalize_db(message: Message, app: App):
     )
 
 
-# todo: auto-determine file type from name.
-# async def extract_payment_from_image(
-#         file_bytes: bytes
-# file_name: str
-# ) -> PaymentInfo:
-# if file_name.endswith(".pdf"):
-#     file_type = "application/pdf"
-## elif file_name.endswith(".jpg") or file_name.endswith(".jpeg") or file_name.endswith(".png"):
-# else:
-#     file_type = "image/{file_name.split('.')[-1]}"
-async def extract_payment_from_image(
-    file_bytes: bytes,
-    file_type: str = "image/jpeg",
-    *,
-    recipient_name: str | None = None,
-    recipient_phone: str | None = None,
-    model: str | None = None,
-) -> PaymentInfo:
-    """Extract amount + payment destination from image/PDF via vision (litellm).
-
-    Destination: if receipt shows *recipient_name* / *recipient_phone* (Maria),
-    set ``paid_to_maria=True``; otherwise assume website payment.
-    """
-    try:
-        name = (recipient_name or "").strip() or "(not provided)"
-        phone = (recipient_phone or "").strip() or "(not provided)"
-        system_prompt = f"""You are a payment receipt analyzer for a Russian meetup.
-Extract:
-1) payment amount in rubles (integer), if clearly visible
-2) whether this looks like a bank/SBP/phone transfer TO Maria (personal transfer),
-   vs a website / card / CloudPayments / online-acquiring payment.
-
-Maria's payment details (match loosely — formatting varies):
-- Name: {name}
-- Phone: {phone}
-
-Set paid_to_maria=true if the recipient matches this name and/or phone
-(phone digits may appear with +7/8/spaces/dashes; name may be partial or transliterated).
-Set paid_to_maria=false for website payments, card checkouts, CloudPayments,
-merchant names unrelated to Maria, or when destination is unclear.
-method_reason: one short phrase in Russian or English explaining the destination guess.
-
-If amount is missing or ambiguous: amount=null, is_valid=false.
-Destination can still be set when amount is unclear."""
-
-        encoded_file = base64.b64encode(file_bytes).decode("utf-8")
-        if file_type not in ["image/jpeg", "image/png", "application/pdf"]:
-            raise ValueError(f"Unsupported file type: {file_type}")
-
-        messages = [
-            {"role": "system", "content": system_prompt},
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": (
-                            "Extract the payment amount and whether this receipt "
-                            "is a transfer to Maria vs a website payment."
-                        ),
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:{file_type};base64,{encoded_file}"},
-                    },
-                ],
-            },
-        ]
-
-        use_model = model or DEFAULT_PAYMENT_PARSE_MODEL
-        response = await acompletion(
-            model=use_model,
-            messages=messages,
-            max_tokens=200,
-            response_format=PaymentInfo,
-        )
-
-        return PaymentInfo(**json.loads(response.choices[0].message.content))  # type: ignore[union-attr]
-    except Exception as e:
-        logger.error(f"Error extracting payment amount: {e}")
-        return PaymentInfo(amount=None, is_valid=False, paid_to_maria=False)
-
-
 def _get_file_info(response) -> Optional[tuple]:
     """Extract file_id and file_type from a message with photo or PDF.
 
@@ -1202,8 +1248,14 @@ async def _download_file(file_id: str) -> Optional[bytes]:
     "parse_payment", "Анализ платежа с помощью Claude", visibility=Visibility.ADMIN_ONLY
 )
 @router.message(Command("parse_payment"), AdminFilter())
-async def parse_payment_handler(message: Message, state: FSMContext):
-    """Hidden admin command to test payment parsing from images/PDFs"""
+async def parse_payment_handler(message: Message, state: FSMContext, app: App):
+    """Analyze one receipt against the selected event's configured admins."""
+    event_id = await _select_event_for_payment(message.chat.id, state, app)
+    if not event_id:
+        return
+    event = await app.get_event_by_id(event_id)
+    recipients = configured_payment_recipients(app.settings, event)
+
     # Ask user to send a payment proof
     response = await ask_user_raw(
         message.chat.id,
@@ -1234,15 +1286,11 @@ async def parse_payment_handler(message: Message, state: FSMContext):
             await status_msg.edit_text("❌ Не удалось скачать файл")
             return
 
-        from src.app import App
-
-        settings = App().settings
         result = await extract_payment_from_image(
             file_data,
             file_type,
-            recipient_name=settings.payment_name,
-            recipient_phone=settings.payment_phone_number,
-            model=getattr(settings, "payment_parse_model", None),
+            recipients=recipients,
+            model=getattr(app.settings, "payment_parse_model", None),
         )
 
         if result.is_valid:
@@ -1250,10 +1298,32 @@ async def parse_payment_handler(message: Message, state: FSMContext):
         else:
             response_text = "❌ Не удалось извлечь сумму платежа"
 
-        method_label = "Маше (перевод)" if result.paid_to_maria else "сайт / карта"
-        response_text += f"\n📍 Куда (AI): <b>{method_label}</b>"
+        method_labels = {
+            PaymentDestination.EVENT_ADMIN: "администратору встречи",
+            PaymentDestination.WEBSITE: "сайт / карта",
+            PaymentDestination.UNKNOWN: "неясно",
+        }
+        status_labels = {
+            ReceiptStatus.SUCCEEDED: "успешно",
+            ReceiptStatus.PENDING: "pending",
+            ReceiptStatus.FAILED: "неуспешно",
+            ReceiptStatus.UNKNOWN: "неясно",
+        }
+        response_text += f"\n📍 Получатель: <b>{method_labels[result.destination]}</b>"
+        response_text += (
+            f"\n🧾 Статус чека: <b>{status_labels[result.receipt_status]}</b>"
+        )
+        if result.recipient_name or result.recipient_phone:
+            receiver = " · ".join(
+                value
+                for value in (result.recipient_name, result.recipient_phone)
+                if value
+            )
+            response_text += f"\n👤 В чеке: <b>{escape(receiver)}</b>"
+        if result.merchant_name:
+            response_text += f"\n🏪 Магазин: <b>{escape(result.merchant_name)}</b>"
         if result.method_reason:
-            response_text += f"\n💬 {result.method_reason}"
+            response_text += f"\n💬 {escape(result.method_reason)}"
 
         await status_msg.edit_text(response_text, parse_mode="HTML")
 

--- a/src/routers/payment.py
+++ b/src/routers/payment.py
@@ -16,8 +16,15 @@ from aiogram.types import (
 from loguru import logger
 from src import templates
 from src.app import App, GraduateType
+from src.payment_proof_analysis import (
+    PaymentDestination,
+    PaymentInfo,
+    configured_payment_recipients,
+    extract_payment_from_image,
+    proof_analysis_payload,
+    resolve_payment_method,
+)
 from src.router import is_admin, commands_menu, get_event_date_display
-from src.routers.admin import PaymentInfo
 from src.ticket_cards import send_paid_ticket_card
 from src.amount_parse import message_text, parse_rubles_amount
 from src.user_interactions import ask_user_raw, ask_user_choice, ask_user_choice_raw
@@ -579,9 +586,9 @@ async def _handle_paid_await_proof(
 ) -> bool:
     """User said they already paid (site or Maria) — ask for screenshot/PDF proof.
 
-    payment_method: "on_site" | "to_maria" (matches choice keys paid_on_site / paid_to_maria).
+    payment_method: "on_site" | "to_admin" (choice keys stay user-facing).
     """
-    method_label = "сайт" if payment_method == "on_site" else "Маша"
+    method_label = "сайт" if payment_method == "on_site" else "администратор"
     await app.log_registration_step(
         user_id=user_id,
         username=username,
@@ -646,14 +653,18 @@ async def _handle_paid_await_proof(
 
 
 def _payment_method_label(method: str | None, *, source: str | None = None) -> str:
-    if method == "to_maria":
-        base = "Маше (перевод)"
+    if method in {"to_admin", "to_maria"}:
+        base = "администратору (перевод)"
     elif method == "on_site":
         base = "сайт / карта"
     else:
         base = "неизвестно"
     if source == "ai":
         return f"{base} · AI"
+    if source == "proof_recipient":
+        return f"{base} · по получателю в чеке"
+    if source == "proof_merchant":
+        return f"{base} · по магазину в чеке"
     if source == "user":
         return f"{base} · выбрал(а)"
     return base
@@ -670,12 +681,23 @@ def _build_user_info_text(
     graduate_type: str,
     payment_method: str | None = None,
     payment_method_source: str | None = None,
+    claimed_payment_method: str | None = None,
+    payment_method_overridden: bool = False,
+    proof_destination: PaymentDestination = PaymentDestination.UNKNOWN,
     method_reason: str | None = None,
 ) -> str:
     user_info = f"👤 Пользователь: {username or ''} (ID: {user_id})\n"
     user_info += f"📍 Город: {city}\n"
     if payment_method:
         user_info += f"📍 Куда: {_payment_method_label(payment_method, source=payment_method_source)}\n"
+        if claimed_payment_method:
+            user_info += (
+                f"🗣 Заявил(а): {_payment_method_label(claimed_payment_method)}\n"
+            )
+        if payment_method_overridden:
+            user_info += "🔁 Автоисправлено по получателю в чеке\n"
+        elif proof_destination == PaymentDestination.UNKNOWN:
+            user_info += "⚠️ Получатель в чеке не распознан — способ оставлен по выбору пользователя\n"
         if method_reason:
             user_info += f"💬 {escape(method_reason)}\n"
     if guests:
@@ -798,8 +820,13 @@ async def _forward_proof_to_events_chat(
 ) -> tuple[str | None, str | None]:
     """Forward proof to events chat. Returns resolved (payment_method, source)."""
     logger.info(f"Starting payment proof forwarding for user {user_id}, city: {city}")
-    events_chat_id = app.settings.events_chat_id
-    logger.info(f"Events chat ID: {events_chat_id}")
+    configured_proof_chat_id = getattr(app.settings, "payment_proofs_chat_id", None)
+    proof_chat_id = (
+        configured_proof_chat_id
+        if isinstance(configured_proof_chat_id, int)
+        else app.settings.events_chat_id
+    )
+    logger.info(f"Payment proof review chat ID: {proof_chat_id}")
 
     # The amount arguments are full group totals so persistence and admin
     # confirmation can never drop named guests. Derive registrant-only values
@@ -838,16 +865,24 @@ async def _forward_proof_to_events_chat(
     logger.info(
         f"Parsing payment info from response: has_photo={has_photo}, has_pdf={has_pdf}"
     )
-    payment_info = await parse_payment_info(response, has_photo, has_pdf, bot)
-
-    # Prefer explicit user choice; otherwise AI destination (Maria name/phone → to_maria).
-    method_reason = payment_info.method_reason
-    if payment_method in ("on_site", "to_maria"):
-        resolved_method = payment_method
-        resolved_source = payment_method_source or "user"
-    else:
-        resolved_method = payment_info.payment_method
-        resolved_source = "ai"
+    event = await app.get_event_by_id(event_id)
+    payment_info = await parse_payment_info(
+        response, has_photo, has_pdf, bot, event=event
+    )
+    resolution = resolve_payment_method(
+        payment_method, payment_method_source, payment_info
+    )
+    analysis = proof_analysis_payload(payment_info, resolution)
+    method_override = (
+        {
+            "from": resolution.claimed_method,
+            "to": resolution.effective_method,
+            "reason": resolution.override_reason,
+            "at": analysis["analyzed_at"],
+        }
+        if resolution.overridden
+        else None
+    )
 
     user_info = _build_user_info_text(
         user_id,
@@ -858,9 +893,12 @@ async def _forward_proof_to_events_chat(
         total_regular_with_guests,
         user_registration,
         graduate_type,
-        payment_method=resolved_method,
-        payment_method_source=resolved_source,
-        method_reason=method_reason if resolved_source == "ai" else None,
+        payment_method=resolution.effective_method,
+        payment_method_source=resolution.source,
+        claimed_payment_method=resolution.claimed_method,
+        payment_method_overridden=resolution.overridden,
+        proof_destination=payment_info.destination,
+        method_reason=payment_info.method_reason,
     )
 
     logger.info(
@@ -883,7 +921,7 @@ async def _forward_proof_to_events_chat(
         photo = response.photo[-1]
         logger.info(f"Sending photo with file_id: {photo.file_id}")
         forwarded_msg = await bot.send_photo(
-            chat_id=events_chat_id,
+            chat_id=proof_chat_id,
             photo=photo.file_id,
             caption=user_info,
             reply_markup=validation_markup,
@@ -897,7 +935,7 @@ async def _forward_proof_to_events_chat(
         )
         logger.info(f"Sending PDF with file_id: {response.document.file_id}")
         forwarded_msg = await bot.send_document(
-            chat_id=events_chat_id,
+            chat_id=proof_chat_id,
             document=response.document.file_id,
             caption=user_info,
             reply_markup=validation_markup,
@@ -914,13 +952,31 @@ async def _forward_proof_to_events_chat(
         screenshot_message_id=forwarded_msg.message_id,
         formula_amount=formula_amount,
         payment_status="pending",
-        payment_method=resolved_method,
-        payment_method_source=resolved_source,
+        payment_method=resolution.effective_method,
+        payment_method_source=resolution.source,
+        payment_method_claimed=resolution.claimed_method,
+        payment_proof_analysis=analysis,
+        payment_method_override=method_override,
     )
+    if resolution.overridden:
+        await app.save_event_log(
+            "payment_correction",
+            {
+                "action": "payment_method_auto_corrected_from_receipt",
+                "event_id": event_id,
+                "previous_method": resolution.claimed_method,
+                "new_method": resolution.effective_method,
+                "proof_message_id": forwarded_msg.message_id,
+                "matched_admin": payment_info.matched_admin,
+                "reason": resolution.override_reason,
+            },
+            user_id,
+            username,
+        )
     logger.info(
         f"Payment proof from user {user_id} sent to validation chat with caption"
     )
-    return resolved_method, resolved_source
+    return resolution.effective_method, resolution.source
 
 
 async def _handle_screenshot_upload(
@@ -990,6 +1046,7 @@ async def _handle_screenshot_upload(
         payment_status="pending",
         payment_method=payment_method,
         payment_method_source=payment_method_source,
+        payment_method_claimed=payment_method,
     )
 
     try:
@@ -1203,7 +1260,7 @@ async def process_payment(
                 total_regular_with_guests,
                 total_formula_with_guests,
                 graduate_type,
-                payment_method="to_maria",
+                payment_method="to_admin",
             )
         if response == "pay_later":
             await _handle_pay_later(
@@ -1252,12 +1309,14 @@ async def process_payment(
 
 
 async def parse_payment_info(
-    response, has_photo: bool, has_pdf: bool, bot
+    response,
+    has_photo: bool,
+    has_pdf: bool,
+    bot,
+    *,
+    event: dict | None = None,
 ) -> PaymentInfo:
-    from src.routers.admin import extract_payment_from_image
-
-    recipient_name = app.settings.payment_name
-    recipient_phone = app.settings.payment_phone_number
+    recipients = configured_payment_recipients(app.settings, event)
     model = app.settings.payment_parse_model
 
     # Get the file
@@ -1268,8 +1327,7 @@ async def parse_payment_info(
         return await extract_payment_from_image(
             file_bytes.read(),
             "image/jpeg",
-            recipient_name=recipient_name,
-            recipient_phone=recipient_phone,
+            recipients=recipients,
             model=model,
         )
     elif has_pdf:
@@ -1280,12 +1338,11 @@ async def parse_payment_info(
         return await extract_payment_from_image(
             file_bytes.read(),
             "application/pdf",
-            recipient_name=recipient_name,
-            recipient_phone=recipient_phone,
+            recipients=recipients,
             model=model,
         )
     else:
-        return PaymentInfo(amount=None, is_valid=False, paid_to_maria=False)
+        return PaymentInfo()
 
 
 # Add payment command handler

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.routers.admin import (
     admin_handler,
+    admin_payment_audit,
     admin_register_payment,
 )
 
@@ -101,7 +102,51 @@ async def test_admin_handler_view_stats(
         mock_stats.assert_called_once_with(mock_message, app=mock_app)
 
         # Verify result is the chosen option
-        assert result == "view_stats"
+    assert result == "view_stats"
+
+
+@pytest.mark.asyncio
+async def test_payment_audit_repairs_admin_recipient_mismatch(
+    mock_message, mock_state, mock_app, mock_send_safe
+):
+    event = _make_event()
+    event_id = str(event["_id"])
+    registration = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "user_id": 111,
+        "username": "nikitin",
+        "full_name": "Иван Никитин",
+        "payment_status": "confirmed",
+        "payment_method": "on_site",
+        "payment_screenshot_id": 123,
+        "payment_proof_analysis": {
+            "destination": "event_admin",
+            "receipt_status": "succeeded",
+        },
+    }
+    mock_app.get_all_events.return_value = [event]
+    mock_app.get_all_users.return_value = [registration]
+    mock_app.settings.event_payments_bridge_enabled = False
+    mock_app.collection.update_one.return_value = MagicMock(modified_count=1)
+
+    with patch(
+        "src.routers.admin.ask_user_choice",
+        new_callable=AsyncMock,
+        return_value=event_id,
+    ):
+        await admin_payment_audit(mock_message, mock_state, mock_app)
+
+    update = mock_app.collection.update_one.await_args.args[1]["$set"]
+    assert update["payment_method"] == "to_admin"
+    assert update["payment_method_source"] == "admin_proof_audit"
+    correction = mock_app.save_event_log.await_args.args
+    assert correction[0] == "payment_correction"
+    assert correction[1]["previous_method"] == "on_site"
+    assert correction[1]["new_method"] == "to_admin"
+    report = mock_send_safe.await_args.args[1]
+    assert "Автоисправлено сейчас: 1" in report
+    assert "требует внимания: 0" in report
 
 
 # TODO: Fix src import path issue

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -718,7 +718,7 @@ def test_build_user_info_text_with_graduation_year():
 
 def test_build_validation_buttons_valid_payment():
     from src.routers.payment import _build_validation_buttons
-    from src.routers.admin import PaymentInfo
+    from src.payment_proof_analysis import PaymentInfo
 
     payment_info = PaymentInfo(amount=1500, is_valid=True)
     buttons = _build_validation_buttons(
@@ -744,7 +744,7 @@ def test_build_validation_buttons_valid_payment():
 
 def test_build_validation_buttons_invalid_with_discount():
     from src.routers.payment import _build_validation_buttons
-    from src.routers.admin import PaymentInfo
+    from src.payment_proof_analysis import PaymentInfo
 
     payment_info = PaymentInfo(amount=None, is_valid=False)
     buttons = _build_validation_buttons(
@@ -764,8 +764,8 @@ def test_build_validation_buttons_invalid_with_discount():
 
 
 def test_build_validation_buttons_formula_higher():
+    from src.payment_proof_analysis import PaymentInfo
     from src.routers.payment import _build_validation_buttons
-    from src.routers.admin import PaymentInfo
 
     payment_info = PaymentInfo(amount=None, is_valid=False)
     buttons = _build_validation_buttons(
@@ -782,8 +782,8 @@ def test_build_validation_buttons_formula_higher():
 
 
 def test_build_validation_buttons_decline_callback_format():
+    from src.payment_proof_analysis import PaymentInfo
     from src.routers.payment import _build_validation_buttons
-    from src.routers.admin import PaymentInfo
 
     payment_info = PaymentInfo(amount=None, is_valid=False)
     buttons = _build_validation_buttons(
@@ -808,7 +808,7 @@ async def test_screenshot_upload_persists_pending_with_forwarded_message_id(
     _mock_botspot_dependencies,
 ):
     from src.app import GraduateType
-    from src.routers.admin import PaymentInfo
+    from src.payment_proof_analysis import PaymentDestination, PaymentInfo
     from src.routers.payment import _handle_screenshot_upload
 
     response = MagicMock(spec=Message)
@@ -821,6 +821,7 @@ async def test_screenshot_upload_persists_pending_with_forwarded_message_id(
         "class_letter": "А",
         "graduate_type": GraduateType.GRADUATE.value,
     }
+    mock_app.get_event_by_id = AsyncMock(return_value={})
     bot = _mock_botspot_dependencies.return_value.bot
     bot.send_photo = AsyncMock(return_value=MagicMock(message_id=888))
 
@@ -828,7 +829,11 @@ async def test_screenshot_upload_persists_pending_with_forwarded_message_id(
         "src.routers.payment.parse_payment_info",
         new=AsyncMock(
             return_value=PaymentInfo(
-                amount=1800, is_valid=True, paid_to_maria=False, method_reason="card"
+                amount=1800,
+                is_valid=True,
+                destination=PaymentDestination.WEBSITE,
+                merchant_name="146.school",
+                method_reason="merchant 146.school",
             )
         ),
     ):
@@ -856,20 +861,21 @@ async def test_screenshot_upload_persists_pending_with_forwarded_message_id(
     assert forwarded_save.kwargs["screenshot_message_id"] == 888
     # Direct upload (no button) → AI destination
     assert forwarded_save.kwargs["payment_method"] == "on_site"
-    assert forwarded_save.kwargs["payment_method_source"] == "ai"
+    assert forwarded_save.kwargs["payment_method_source"] == "proof_merchant"
+    assert forwarded_save.kwargs["payment_proof_analysis"]["destination"] == "website"
     caption = bot.send_photo.await_args.kwargs["caption"]
     assert "сайт" in caption.lower() or "карта" in caption.lower()
 
 
 @pytest.mark.asyncio
-async def test_screenshot_upload_ai_detects_maria(
+async def test_screenshot_recipient_overrides_user_website_choice(
     mock_message,
     mock_app,
     mock_send_safe,
     _mock_botspot_dependencies,
 ):
     from src.app import GraduateType
-    from src.routers.admin import PaymentInfo
+    from src.payment_proof_analysis import PaymentDestination, PaymentInfo
     from src.routers.payment import _handle_screenshot_upload
 
     response = MagicMock(spec=Message)
@@ -880,6 +886,7 @@ async def test_screenshot_upload_ai_detects_maria(
         "full_name": "Тест",
         "graduate_type": GraduateType.GRADUATE.value,
     }
+    mock_app.get_event_by_id = AsyncMock(return_value={})
     bot = _mock_botspot_dependencies.return_value.bot
     bot.send_photo = AsyncMock(return_value=MagicMock(message_id=202))
 
@@ -889,7 +896,10 @@ async def test_screenshot_upload_ai_detects_maria(
             return_value=PaymentInfo(
                 amount=1500,
                 is_valid=True,
-                paid_to_maria=True,
+                destination=PaymentDestination.EVENT_ADMIN,
+                recipient_name="Мария Денисовна К.",
+                recipient_phone="+7 919 488-89-10",
+                matched_admin="Мария",
                 method_reason="phone match",
             )
         ),
@@ -907,30 +917,50 @@ async def test_screenshot_upload_ai_detects_maria(
             regular_amount=1500,
             formula_amount=1500,
             graduate_type=GraduateType.GRADUATE.value,
+            payment_method="on_site",
+            payment_method_source="user",
         )
 
     forwarded_save = mock_app.save_payment_info.await_args_list[-1]
-    assert forwarded_save.kwargs["payment_method"] == "to_maria"
-    assert forwarded_save.kwargs["payment_method_source"] == "ai"
+    assert forwarded_save.kwargs["payment_method"] == "to_admin"
+    assert forwarded_save.kwargs["payment_method_source"] == "proof_recipient"
+    assert forwarded_save.kwargs["payment_method_claimed"] == "on_site"
+    assert forwarded_save.kwargs["payment_method_override"]["from"] == "on_site"
+    assert forwarded_save.kwargs["payment_method_override"]["to"] == "to_admin"
     caption = bot.send_photo.await_args.kwargs["caption"]
-    assert "Маше" in caption
+    assert "администратору" in caption
+    assert "Автоисправлено" in caption
+    correction = next(
+        call
+        for call in mock_app.save_event_log.await_args_list
+        if call.args[0] == "payment_correction"
+    )
+    assert correction.args[1]["previous_method"] == "on_site"
+    assert correction.args[1]["new_method"] == "to_admin"
 
 
 def test_payment_info_method_property():
-    from src.routers.admin import PaymentInfo
+    from src.payment_proof_analysis import PaymentDestination, PaymentInfo
 
-    assert PaymentInfo(amount=1, is_valid=True, paid_to_maria=True).payment_method == (
-        "to_maria"
+    assert (
+        PaymentInfo(
+            amount=1, is_valid=True, destination=PaymentDestination.EVENT_ADMIN
+        ).payment_method
+        == "to_admin"
     )
-    assert PaymentInfo(amount=1, is_valid=True, paid_to_maria=False).payment_method == (
-        "on_site"
+    assert (
+        PaymentInfo(
+            amount=1, is_valid=True, destination=PaymentDestination.WEBSITE
+        ).payment_method
+        == "on_site"
     )
+    assert PaymentInfo(amount=1, is_valid=True).payment_method is None
 
 
 def test_payment_method_label():
     from src.routers.payment import _payment_method_label
 
-    assert "AI" in _payment_method_label("to_maria", source="ai")
+    assert "получателю" in _payment_method_label("to_admin", source="proof_recipient")
     assert "выбрал" in _payment_method_label("on_site", source="user")
 
 
@@ -1244,7 +1274,7 @@ async def test_process_payment_paid_to_maria_asks_for_proof(
         for c in mock_app.save_event_log.call_args_list
         if c[0] and isinstance(c[0][1], dict)
     ]
-    assert "paid_to_maria_selected" in actions
+    assert "paid_to_admin_selected" in actions
 
 
 class TestSeasonAdjective:

--- a/tests/test_payment_proof_analysis.py
+++ b/tests/test_payment_proof_analysis.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from src.payment_proof_analysis import (
+    PaymentDestination,
+    PaymentInfo,
+    PaymentRecipient,
+    ReceiptStatus,
+    configured_payment_recipients,
+    proof_analysis_payload,
+    resolve_payment_method,
+    validate_destination,
+)
+
+
+def test_configured_phone_match_makes_admin_destination_authoritative():
+    info = PaymentInfo(
+        amount=2400,
+        is_valid=True,
+        destination=PaymentDestination.WEBSITE,
+        recipient_name="Мария Денисовна К.",
+        recipient_phone="+7 (919) 488-89-10",
+        receipt_status=ReceiptStatus.SUCCEEDED,
+    )
+    recipients = [
+        PaymentRecipient(
+            name="Мария Денисовна Корсакова",
+            phone="8 919 488 89 10",
+            label="Мария",
+        )
+    ]
+
+    validated = validate_destination(info, recipients)
+
+    assert validated.destination == PaymentDestination.EVENT_ADMIN
+    assert validated.matched_admin == "Мария"
+
+
+def test_unsubstantiated_admin_classification_is_downgraded_to_unknown():
+    info = PaymentInfo(
+        amount=1300,
+        is_valid=True,
+        destination=PaymentDestination.EVENT_ADMIN,
+        recipient_name="Иван Иванов",
+    )
+
+    validated = validate_destination(
+        info, [PaymentRecipient(name="Мария Корсакова", phone="+7 900 000-00-00")]
+    )
+
+    assert validated.destination == PaymentDestination.UNKNOWN
+    assert validated.payment_method is None
+
+
+def test_receipt_admin_overrides_claimed_website_but_unknown_does_not():
+    admin_info = PaymentInfo(destination=PaymentDestination.EVENT_ADMIN)
+    admin_resolution = resolve_payment_method("on_site", "user", admin_info)
+    assert admin_resolution.effective_method == "to_admin"
+    assert admin_resolution.source == "proof_recipient"
+    assert admin_resolution.overridden is True
+
+    unknown_resolution = resolve_payment_method("on_site", "user", PaymentInfo())
+    assert unknown_resolution.effective_method == "on_site"
+    assert unknown_resolution.source == "user"
+    assert unknown_resolution.overridden is False
+
+
+def test_event_recipients_override_legacy_global_recipient():
+    settings = SimpleNamespace(payment_name="Мария", payment_phone_number="111")
+    event = {
+        "payment_recipients": [
+            {"name": "Анна Петрова", "phone": "222", "label": "Анна"}
+        ]
+    }
+
+    recipients = configured_payment_recipients(settings, event)
+
+    assert [recipient.label for recipient in recipients] == ["Анна"]
+
+
+def test_analysis_payload_keeps_status_and_precedence_decision():
+    info = PaymentInfo(
+        amount=1100,
+        is_valid=True,
+        destination=PaymentDestination.EVENT_ADMIN,
+        receipt_status=ReceiptStatus.PENDING,
+        matched_admin="Мария",
+    )
+    resolution = resolve_payment_method("on_site", "user", info)
+
+    payload = proof_analysis_payload(info, resolution)
+
+    assert payload["destination"] == "event_admin"
+    assert payload["receipt_status"] == "pending"
+    assert payload["claimed_method"] == "on_site"
+    assert payload["effective_method"] == "to_admin"
+    assert payload["overridden"] is True

--- a/tests/test_payment_proof_retention.py
+++ b/tests/test_payment_proof_retention.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.app import AppSettings
+from src.payment_proof_retention import configure_payment_proof_retention
+
+
+def settings(**overrides) -> AppSettings:
+    values = {
+        "telegram_bot_token": "token",
+        "events_chat_id": -1001,
+        "payment_phone_number": "phone",
+        "payment_name": "Maria",
+    }
+    values.update(overrides)
+    return AppSettings(**values)
+
+
+@pytest.mark.asyncio
+async def test_retention_requires_dedicated_chat():
+    bot = AsyncMock()
+
+    assert await configure_payment_proof_retention(bot, settings()) is False
+    assert (
+        await configure_payment_proof_retention(
+            bot, settings(payment_proofs_chat_id=-1001)
+        )
+        is False
+    )
+    bot.set_chat_message_auto_delete_time.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retention_sets_one_year_timer_on_dedicated_chat():
+    bot = AsyncMock()
+
+    assert (
+        await configure_payment_proof_retention(
+            bot, settings(payment_proofs_chat_id=-2002)
+        )
+        is True
+    )
+    bot.set_chat_message_auto_delete_time.assert_awaited_once_with(
+        chat_id=-2002,
+        message_auto_delete_time=31_536_000,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3843,7 +3843,7 @@ wheels = [
 
 [[package]]
 name = "register-146-meetup-2025-bot"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## What changed

- extract receipt destination, status, recipient, merchant, and method evidence into a structured payment-proof model
- preserve the user claim, proof-derived method, overrides, and correction audit events
- add an admin proof audit for exact recipient mismatches
- route proofs to a dedicated review chat and configure one-year Telegram retention only there
- document the MongoDB/PostgreSQL production-data boundary and retention runbook
- bump the project patch version to 0.2.5

## Why

The previous flow collapsed user choice and AI classification into one method and could not show why a method was chosen. Chat-wide Telegram retention would also be unsafe on the general events chat.

## Impact

Admins get evidence-first reconciliation and explicit ambiguity. Existing `to_maria` records remain display-compatible, while new personal transfers use the generic `to_admin` method. Retention remains inactive unless a distinct `PAYMENT_PROOFS_CHAT_ID` is configured.

## Checks

- `uv run --frozen pytest -q`: 788 passed
- `uv run --frozen ruff check .`
- `git diff --check origin/dev...HEAD`

### CI hygiene

CI hygiene: moves Lizard `continue-on-error` to the analysis step so the check named “Complexity (advisory)” is genuinely non-blocking. Current head passes Ruff, Pyright, Vulture, Python 3.13 tests, coverage, and complexity.
